### PR TITLE
Plugin system (static + WASM) — v0.4.0 staging merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,10 @@ jobs:
       - name: cargo clippy — default features
         run: cargo clippy -- -D warnings
 
-      # v0.3.0+ — activate when optional features are declared in Cargo.toml
+      - name: cargo clippy — feature wasm-plugins
+        run: cargo clippy --features wasm-plugins -- -D warnings
+
+      # v0.5.0+ — activate when async feature flag is declared in Cargo.toml
       # - name: cargo clippy — feature async
       #   run: cargo clippy --features async -- -D warnings
 
@@ -78,8 +81,14 @@ jobs:
       - name: cargo test — default features
         run: cargo test
 
+      - name: cargo test — feature wasm-plugins
+        run: cargo test --features wasm-plugins
+
       - name: cargo test — doc examples
         run: cargo test --doc
+
+      - name: cargo test — doc examples (feature wasm-plugins)
+        run: cargo test --doc --features wasm-plugins
 
       # v0.5.0+ — activate when async feature flag is declared in Cargo.toml
       # - name: cargo test — feature async

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -67,14 +67,15 @@ jobs:
           cargo llvm-cov --all-targets --workspace \
             --lcov --output-path lcov-default.info
 
-      # ── Run 2 : all features ──────────────────────────────────────────────
-      # Activate at v0.5.0 when Cargo.toml declares optional features.
-      # Replace lcov-default.info with lcov-all.info in the upload step below.
-      #
-      # - name: Generate code coverage — all features
-      #   run: |
-      #     cargo llvm-cov --all-targets --all-features --workspace \
-      #       --lcov --output-path lcov-all.info
+      # ── Run 2 : wasm-plugins feature ───────────────────────────────────────
+      # Activated at v0.4.0 — covers src/plugin/wasm.rs (Option C, DD-021).
+      # Uses --features wasm-plugins rather than --all-features so that the
+      # umbrella report stays scoped to currently declared features; revisit
+      # this comment when a second feature flag is introduced.
+      - name: Generate code coverage — feature wasm-plugins
+        run: |
+          cargo llvm-cov --all-targets --features wasm-plugins --workspace \
+            --lcov --output-path lcov-wasm-plugins.info
 
       # ── Run 3 : async feature ─────────────────────────────────────────────
       # Activate at v0.5.0 when Cargo.toml declares: [features] async = [...]
@@ -87,7 +88,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
-          files: lcov-default.info
+          files: lcov-default.info,lcov-wasm-plugins.info
           fail_ci_if_error: false
           flags: unittests
           name: codecov-umbrella
@@ -98,7 +99,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report
-          path: lcov-default.info
+          path: |
+            lcov-default.info
+            lcov-wasm-plugins.info
           retention-days: 30
 
       - name: Display coverage summary

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ exclude = [
     "tests/integration/",
 ]
 
+[features]
+wasm-plugins = ["dep:wasmtime"]
+
 [dependencies]
 # Serialization and configuration parsing
 serde = { version = "1.0", features = ["derive"] }
@@ -38,6 +41,9 @@ rustyline = "14.0"
 
 # System utilities
 dirs = "5.0"
+
+# WASM plugin runtime (optional — enabled via features = ["wasm-plugins"])
+wasmtime = { version = "45.0.0", optional = true }
 
 [dev-dependencies]
 # Testing utilities

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,17 @@ name = "dynamic_cli"
 path = "src/lib.rs"
 doctest = true
 
+# Integration tests under tests/integration/ — not auto-discovered by Cargo
+# since they live in a subdirectory rather than directly under tests/.
+[[test]]
+name = "system_plugin_test"
+path = "tests/integration/system_plugin_test.rs"
+
+[[test]]
+name = "wasm_plugin_test"
+path = "tests/integration/wasm_plugin_test.rs"
+required-features = ["wasm-plugins"]
+
 # Benchmark configuration (uncomment when benchmarks are implemented)
 # [[bench]]
 # name = "parser_benchmarks"

--- a/PLUGIN_GUIDE.fr.md
+++ b/PLUGIN_GUIDE.fr.md
@@ -1,0 +1,802 @@
+# Guide de conception de plugins — `dynamic-cli`
+
+>Prise en main de la réalisation et de l'enregistrement de plugins pour une application tierce utilisant le crate `dynamic-cli`.
+
+* Contexte de décision :
+  * Décision de conception (architecture du système de plugins) [DD-021](https://github.com/biface/dcli/issues/10)
+  * implémentation des plugins statiques : [trait `Plugin`](https://github.com/biface/dcli/issues/22)
+  * implémentation des plugins encapsulés en environnement WASM : [`WasmPlugin`](https://github.com/biface/dcli/issues/23)
+* **Dernière mise à jour** : 2026-06-17 (v0.4.0)
+
+---
+
+## Vue d'ensemble
+
+`dynamic-cli` propose deux façons d'étendre une application avec des handlers qui ne vivent pas dans le crate de l'application hôte elle-même :
+
+| Mécanisme                              | Quand l'utiliser                                                                                    | Coût                                                                                                   |
+|----------------------------------------|-----------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|
+| **Plugins statiques** (trait `Plugin`) | Le code du plugin est compilé dans le binaire hôte                                                  | Aucun `unsafe`, aucune dépendance supplémentaire, aucun surcoût à l'exécution                          |
+| **Plugins WASM** (`WasmPlugin`)        | Le plugin doit être distribué et chargé indépendamment du binaire hôte, ou exécuté dans une sandbox | Dépendance `wasmtime` (opt-in via `features = ["wasm-plugins"]`), contrat ABI côté guest à implémenter |
+
+Une troisième option a été envisagée puis **exclue définitivement** : le chargement dynamique de bibliothèques natives via `libloading`. L'ABI de Rust n'est pas stable entre les versions du compilateur, ce qui rend cette approche structurellement non sûre, quelle que soit la qualité de l'implémentation.
+
+Les deux mécanismes supportés partagent un même principe architectural, hérité de la conception "config-first" du framework : **la configuration YAML reste l'unique source de vérité pour les définitions de commandes.**
+
+En d'autres termes, un plugin — statique ou WASM — ne déclare jamais ses propres commandes. Il ne fournit que le *handler* d'une commande que l'application hôte a déjà déclarée dans sa configuration YAML.
+
+---
+
+## Le contrat YAML commun
+
+Qu'un handler provienne d'un plugin statique, d'un plugin WASM, ou d'un appel direct à `CliBuilder::register_handler()`, chacun respecte le même formalisme d'enregistrement dans le fichier de configuration YAML.
+
+Une entrée de commande nomme une `implementation`, et *quelque chose* doit fournir un handler sous ce nom exact au moment où `CliBuilder::build()` s'exécute. Pour plus d'éléments sur la configuration YAML, voir [La syntaxe de configuration](CONFIG_SYNTAX_REFERENCE.fr.md).
+
+```yaml
+commands:
+  - name: greet
+    description: "Greet someone"
+    implementation: greet_hello   # <- c'est cette clé qu'un plugin doit faire correspondre
+    arguments: []
+    options: []
+```
+
+La méthode de construction `build()` ne se préoccupe pas de l'origine de `greet_hello`. Qu'il vienne de `Plugin::handlers()` d'un plugin statique, de la fonction métier mappée d'un plugin WASM, ou d'un `Box<dyn CommandHandler>` enregistré directement, tous sont fusionnés dans la même table de résolution interne avant que les commandes ne soient résolues.
+
+Cela permet en outre de combiner plusieurs mécanismes dans une même application : un `SystemPlugin` pour `help`/`version`/`exit`, un plugin WASM pour une commande tierce sandboxée, et un handler natif écrit à la main pour la logique métier centrale de l'application peuvent tous coexister — à condition qu'aucun de ces mécanismes ne revendique le même nom `implementation`.
+
+Si deux sources tentent de fournir le même nom `implementation`, `build()` échoue avec une erreur de conflit explicite plutôt que de laisser l'une écraser silencieusement l'autre. Voir [Détection de conflit](#détection-de-conflit) ci-dessous.
+
+---
+
+## Plugins statiques
+
+### Le trait `Plugin`
+
+```rust
+pub trait Plugin: Send + Sync {
+    fn name(&self) -> &str;
+    fn version(&self) -> &str;
+    fn description(&self) -> &str;
+    fn handlers(&self) -> Vec<(String, Box<dyn CommandHandler>)>;
+}
+```
+
+Un plugin déclare des métadonnées — `name`, `version`, `description`, utilisées pour l'introspection, par exemple lister les plugins chargés — et les handlers qu'il fournit, chacun étiqueté avec le nom `implementation` auquel il doit correspondre.
+
+Le trait est délibérément *déclaratif* : un plugin retourne ses handlers, il ne reçoit pas un `&mut CommandRegistry` pour les enregistrer lui-même.
+
+Cela maintient le contrôle de l'enregistrement du côté du framework, pas du plugin. C'est exactement le même schéma que suit `CommandHandler` lui-même : un handler déclare sa logique d'exécution, le framework décide quand l'invoquer.
+
+Cela permet également au framework de valider chaque nom de handler avant qu'aucun d'eux ne touche le registre — ce qui rend possible une détection de conflit propre (voir ci-dessous) plutôt que de laisser un plugin écraser silencieusement une commande existante.
+
+### Enregistrer un plugin statique
+
+```rust
+use dynamic_cli::CliBuilder;
+use dynamic_cli::plugin::SystemPlugin;
+
+let app = CliBuilder::new()
+    .config_file("commands.yaml")
+    .context(Box::new(MyContext::default()))
+    .register_plugin(Box::new(SystemPlugin::new()))
+    .build()?;
+```
+
+`register_plugin()` peut être appelé plusieurs fois, et librement combiné avec `register_handler()` pour les handlers qui ne proviennent pas d'un plugin.
+
+### `SystemPlugin` — l'implémentation de référence
+
+`dynamic-cli` fournit un plugin statique prêt à l'emploi : [`SystemPlugin`](../src/plugin/system.rs), qui fournit les trois commandes dont presque toute application a besoin :
+
+| Nom `implementation` | Comportement                                                        |
+|----------------------|---------------------------------------------------------------------|
+| `system_help`        | Affiche l'aide globale ou par commande via le `HelpFormatter` actif |
+| `system_version`     | Affiche la version depuis `metadata.version` de la config           |
+| `system_exit`        | Exécute un callback d'arrêt, puis quitte                            |
+
+
+```yaml
+commands:
+  - name: help
+    implementation: system_help
+    aliases: ["h", "?"]
+    description: "Show help"
+    arguments: []
+    options: []
+
+  - name: version
+    implementation: system_version
+    description: "Show version"
+    arguments: []
+    options: []
+
+  - name: exit
+    implementation: system_exit
+    aliases: ["quit", "q"]
+    description: "Exit the application"
+    arguments: []
+    options: []
+```
+
+```rust
+CliBuilder::new()
+    .config_file("commands.yaml")
+    .context(Box::new(MyContext::default()))
+    .register_plugin(Box::new(SystemPlugin::new()))
+    .build()?
+    .run()
+```
+
+#### Callback d'arrêt (shutdown)
+
+Le comportement par défaut de `system_exit` est `std::process::exit(0)`. Une application qui a besoin d'une séquence d'arrêt propre — vider des logs, fermer des connexions, sauvegarder un état — peut fournir son propre callback :
+
+```rust
+SystemPlugin::new()
+    .with_exit_fn(|| {
+        eprintln!("Saving session…");
+        // fermer les ressources ici
+        std::process::exit(0);
+    })
+```
+
+Le callback s'exécute avant la terminaison du processus ; c'est à l'application qu'il revient de réellement quitter à la fin de celui-ci.
+
+### Écrire son propre plugin statique
+
+Un plugin statique est n'importe quel type qui implémente `Plugin`. Aucun échafaudage ni macro n'est requis — voir le rustdoc de `src/plugin/mod.rs` pour un exemple minimal complet, et `src/plugin/system.rs` pour un plugin avec plusieurs handlers et une configuration fournie au constructeur (`with_config`, `with_exit_fn`).
+
+#### Exemple concret — un plugin de diagnostic pour `chrom-rs`
+
+`chrom-rs` est une application de simulation de chromatographie en phase liquide. Ses scénarios sont pilotés par trois fichiers YAML indépendants (`model.yml`, `scenario.yml`, `solver.yml`) consommés par la commande `chrom-rs run`.
+
+Avant de lancer une simulation potentiellement longue — RK4 sur plusieurs milliers de points temporels — il est utile de pouvoir valider la cohérence des trois fichiers sans exécuter le solveur.
+
+L'exemple ci-dessous reprend la structure réelle de `chrom-rs` : son `ExecutionContext` (`ChromContext`, qui porte un `project_dir` validé), le pattern de downcast utilisé par `RunHandler`, et le schéma d'options tel que défini dans `commands.yml`.
+
+Le plugin vit dans son propre fichier, à côté de `app.rs`, comme un nouveau sous-module de `src/cli/` :
+
+```
+src/cli/
+    mod.rs           — build_app(), orchestration (existant)
+    app.rs           — ChromContext, RunHandler (existant)
+    diagnostics.rs   — DiagnosticsPlugin, ValidateConfigHandler (nouveau)
+```
+
+`src/cli/diagnostics.rs` :
+
+```rust
+use dynamic_cli::plugin::Plugin;
+use dynamic_cli::executor::CommandHandler;
+use dynamic_cli::context::ExecutionContext;
+use dynamic_cli::error::ExecutionError;
+use dynamic_cli::DynamicCliError;
+use std::collections::HashMap;
+
+use crate::cli::app::ChromContext;
+
+/// Plugin de diagnostic pour chrom-rs : vérifie la présence des fichiers
+/// de configuration avant une exécution coûteuse.
+struct DiagnosticsPlugin;
+
+impl Plugin for DiagnosticsPlugin {
+    fn name(&self) -> &str { "chrom-diagnostics" }
+    fn version(&self) -> &str { "1.0.0" }
+    fn description(&self) -> &str {
+        "Validation des fichiers model/scenario/solver avant simulation"
+    }
+
+    fn handlers(&self) -> Vec<(String, Box<dyn CommandHandler>)> {
+        vec![
+            ("validate_config".to_string(), Box::new(ValidateConfigHandler)),
+        ]
+    }
+}
+
+struct ValidateConfigHandler;
+
+impl CommandHandler for ValidateConfigHandler {
+    fn execute(
+        &self,
+        ctx: &mut dyn ExecutionContext,
+        args: &HashMap<String, String>,
+    ) -> dynamic_cli::Result<()> {
+        // Même pattern de downcast que RunHandler (src/cli/app.rs) : le
+        // plugin a besoin du project_dir déjà validé par ChromContext,
+        // pas d'un chemin brut.
+        let chrom_ctx = ctx
+            .as_any_mut()
+            .downcast_mut::<ChromContext>()
+            .ok_or_else(|| {
+                DynamicCliError::from(ExecutionError::ContextDowncastFailed {
+                    expected_type: "ChromContext".to_string(),
+                    suggestion: None,
+                })
+            })?;
+
+        let project_dir = chrom_ctx.project_dir();
+
+        // Les valeurs par défaut ("model.yml", "scenario.yml", "solver.yml")
+        // sont désormais portées par `default:` dans commands.yml et déjà
+        // appliquées par le parser avant que ce handler ne s'exécute
+        // (`CliParser::apply_defaults`) — args.get() ne devrait donc jamais
+        // renvoyer None ici tant que le YAML reste cohérent avec la commande
+        // déclarée. Le filet de sécurité ci-dessous reste défensif, pas
+        // nécessaire en usage normal.
+        let model = args.get("model").map(String::as_str).unwrap_or("model.yml");
+        let scenario = args.get("scenario").map(String::as_str).unwrap_or("scenario.yml");
+        let solver = args.get("solver").map(String::as_str).unwrap_or("solver.yml");
+
+        for (label, file) in [("model", model), ("scenario", scenario), ("solver", solver)] {
+            let path = project_dir.join(file);
+            if !path.is_file() {
+                println!("✗ {label} : fichier introuvable ({})", path.display());
+            } else {
+                println!("✓ {label} : {}", path.display());
+            }
+        }
+
+        // Une vraie implémentation pousserait la validation plus loin :
+        // cohérence des espèces chimiques entre model.yml et scenario.yml,
+        // bornes du domaine compatibles avec la configuration du solveur.
+        Ok(())
+    }
+}
+```
+
+Voici le fichier `commands.yml` complet de `chrom-rs`, avec la commande `validate-config` du plugin intégrée à côté de la commande `run` existante (chaque champ — `short`, `long`, `option_type`, `default`, `choices` — est requis par le schéma, voir [`CONFIG_SYNTAX_REFERENCE.fr.md`](CONFIG_SYNTAX_REFERENCE.fr.md)) :
+
+```yaml
+metadata:
+  version: "0.2.0"
+  prompt: "chrom-rs"
+  prompt_suffix: " > "
+
+commands:
+  - name: run
+    aliases:
+      - simulate
+    description: "Run a chromatography simulation from three configuration files."
+    required: true
+    arguments: []
+    options:
+      - name: project-dir
+        short: "d"
+        long: project-dir
+        option_type: path
+        required: false
+        default: "."
+        description: "Root directory for all file names (no '..' allowed)."
+        choices: []
+
+      - name: model
+        short: "m"
+        long: model
+        option_type: string
+        required: true
+        default: ~
+        description: "Model configuration file (e.g. model.yml)."
+        choices: []
+
+      - name: scenario
+        short: "s"
+        long: scenario
+        option_type: string
+        required: true
+        default: ~
+        description: "Scenario configuration file (e.g. scenario.yml)."
+        choices: []
+
+      - name: solver
+        short: "S"
+        long: solver
+        option_type: string
+        required: true
+        default: ~
+        description: "Solver configuration file (e.g. solver.yml)."
+        choices: []
+
+      - name: output-csv
+        short: ~
+        long: output-csv
+        option_type: path
+        required: false
+        default: ~
+        description: "Write simulation results to a CSV file."
+        choices: []
+
+      - name: output-plot
+        short: ~
+        long: output-plot
+        option_type: path
+        required: false
+        default: ~
+        description: "Save chromatogram plot to a PNG or SVG file."
+        choices: []
+
+      - name: export-json
+        short: ~
+        long: export-json
+        option_type: path
+        required: false
+        default: ~
+        description: "Export full simulation result to a JSON file."
+        choices: []
+
+    implementation: run_handler
+
+  # ──────────────────────────────────────────────────────────────────────
+  # Nouvelle commande — fournie par DiagnosticsPlugin (src/cli/diagnostics.rs)
+  # Voir PLUGIN_GUIDE.fr.md, section "Plugins statiques".
+  # ──────────────────────────────────────────────────────────────────────
+  - name: validate-config
+    aliases:
+      - check
+    description: "Valide la présence des fichiers model/scenario/solver avant simulation."
+    required: false
+    arguments: []
+    options:
+      - name: project-dir
+        short: "d"
+        long: project-dir
+        option_type: path
+        required: false
+        default: "."
+        description: "Root directory for all file names (no '..' allowed)."
+        choices: []
+
+      - name: model
+        short: "m"
+        long: model
+        option_type: string
+        required: false
+        default: "model.yml"
+        description: "Model configuration file (e.g. model.yml)."
+        choices: []
+
+      - name: scenario
+        short: "s"
+        long: scenario
+        option_type: string
+        required: false
+        default: "scenario.yml"
+        description: "Scenario configuration file (e.g. scenario.yml)."
+        choices: []
+
+      - name: solver
+        short: "S"
+        long: solver
+        option_type: string
+        required: false
+        default: "solver.yml"
+        description: "Solver configuration file (e.g. solver.yml)."
+        choices: []
+
+    implementation: validate_config
+
+global_options: []
+```
+
+Le bloc `run` est inchangé par rapport au fichier original — seul le bloc `validate-config` est nouveau, ajouté par le plugin. Les options `project-dir`/`model`/`scenario`/`solver` réutilisent volontairement les mêmes shorts (`-d`/`-m`/`-s`/`-S`) que `run` : chaque commande a son propre espace de noms pour ses options courtes, donc aucune collision n'est possible entre deux commandes différentes.
+
+Et l'enregistrement, dans `src/cli/mod.rs` de `chrom-rs`, à côté de `RunHandler`. Deux ajouts par rapport au fichier existant : la déclaration du nouveau sous-module, et l'appel `register_plugin` dans `build_app` :
+
+```rust
+// Nouveau, à côté de `pub mod app;`
+pub mod diagnostics;
+
+use app::{ChromContext, RunHandler};
+use diagnostics::DiagnosticsPlugin;
+
+pub fn build_app() -> anyhow::Result<CliApp> {
+    let config =
+        load_yaml(COMMANDS_YML).map_err(|e| anyhow!("embedded commands.yml is invalid: {e}"))?;
+
+    CliBuilder::new()
+        .config(config)
+        .context(Box::new(ChromContext::new()))
+        .register_handler(RUN_HANDLER_NAME, Box::new(RunHandler))
+        .register_plugin(Box::new(DiagnosticsPlugin))
+        .build()
+        .map_err(|e| anyhow!("CLI builder error: {e}"))
+}
+```
+
+Ce plugin coexiste avec la commande `run` propre à `chrom-rs` — un handler natif, pas un plugin — sans aucune interférence. C'est exactement le scénario de [coexistence](#le-contrat-yaml-commun) décrit plus haut : `run_handler` (natif) et `validate_config` (plugin) sont fusionnés dans la même table par `build()`.
+
+---
+
+## Plugins WASM
+
+### Le concept
+
+#### Qui est l'hôte, qui est le guest
+
+Trois acteurs distincts interviennent, et il est important de ne pas les confondre.
+
+`dynamic-cli` est une bibliothèque. Elle ne s'exécute jamais seule — elle est compilée à l'intérieur du binaire d'une application tierce, comme `chrom-rs`.
+
+C'est cette **application tierce, avec `dynamic-cli` compilé dedans**, qui constitue l'**hôte**. L'hôte est donc le processus qui tourne réellement sur la machine de l'utilisateur final — `dynamic-cli` n'est qu'une partie du code de ce processus, pas le processus lui-même.
+
+Le **guest** est le module `.wasm` chargé par cet hôte. Il s'exécute dans une sandbox fournie par `wasmtime`, lui-même appelé depuis le code de `dynamic-cli`.
+
+```mermaid
+graph LR
+    subgraph Processus hôte
+        A["Application tierce<br/>(ex: chrom-rs)"] --> B["dynamic-cli<br/>(bibliothèque)"]
+        B --> C["wasmtime<br/>(runtime)"]
+    end
+    C -.->|sandbox| D["Module .wasm<br/>(guest)"]
+```
+
+Quand ce guide emploie "l'hôte" dans le contexte WASM, il désigne donc le code de `dynamic-cli` agissant pour le compte de l'application qui l'utilise — pas l'application elle-même au sens de sa logique métier, et certainement pas le guest.
+
+#### Pourquoi une sandbox
+
+Un plugin WASM est un module binaire (`.wasm`) compilé séparément de `dynamic-cli` et de l'application hôte.
+
+Contrairement à un plugin statique — qui partage l'espace mémoire du processus hôte — un plugin WASM s'exécute dans son propre espace mémoire linéaire, isolé.
+
+L'hôte ne peut ni lire ni écrire directement dans la mémoire du guest. Le guest ne peut pas davantage accéder à la mémoire de l'hôte. Tout échange de données passe par un protocole explicite — alloué côté guest, écrit par l'hôte, lu par le guest — plutôt que par un partage direct de structures Rust.
+
+Cette isolation a un coût : sérialisation des arguments, allocation et libération à chaque appel.
+
+Elle a aussi une contrepartie : le plugin peut être écrit dans n'importe quel langage capable de cibler WASM, distribué comme un simple fichier binaire indépendamment du binaire de l'application hôte, et chargé sans recompilation de cette dernière.
+
+### Comment c'est mis en œuvre dans `dynamic-cli`
+
+```mermaid
+sequenceDiagram
+    participant App as Application hôte
+    participant Builder as CliBuilder
+    participant Handler as WasmHandler
+    participant Store as wasmtime::Store/Instance
+    participant Guest as Module .wasm (sandbox)
+
+    App->>Builder: register_wasm_plugin(path, function_map)
+    Builder->>Builder: WasmPlugin::load() — vérifie memory,<br/>dcli_alloc, dcli_dealloc
+
+    Note over App,Guest: --- À l'exécution d'une commande ---
+
+    App->>Handler: execute(ctx, args)
+    Handler->>Handler: Sérialise args (YAML par défaut)
+    Handler->>Store: new Store + Instance (frais, isolé)
+    Handler->>Guest: dcli_alloc(len) -> ptr
+    Handler->>Guest: memory.write(ptr, buffer)
+    Handler->>Guest: business_fn(ptr, len) -> code
+    Handler->>Guest: dcli_dealloc(ptr, len)  [toujours appelé]
+
+    alt code == 0
+        Guest-->>Handler: succès
+        Handler-->>App: Ok(())
+    else code != 0
+        Handler->>Guest: dcli_last_error_message() [si exporté]
+        Guest-->>Handler: (ptr, len) du message, ou rien
+        Handler-->>App: Err(WasmError::GuestError)
+    end
+```
+
+Trois points structurants ressortent de ce schéma.
+
+**Le chargement et l'exécution sont deux phases distinctes.** `WasmPlugin::load` valide les exports obligatoires une seule fois, au chargement — pas à chaque appel de commande.
+
+**Chaque appel obtient son propre `Store`/`Instance`.** Aucun état ne persiste entre deux invocations de la même commande. C'est délibéré : ça garantit l'isolation et évite les fuites d'état entre appels.
+
+**`dcli_dealloc` est appelé sur tous les chemins de sortie**, y compris en cas d'erreur du guest. C'est ce qui garantit qu'une session REPL longue n'accumule pas de mémoire non libérée côté guest.
+
+### Activer le mécanisme
+
+Les plugins WASM échangent le couplage à la compilation des plugins statiques contre une exécution sandboxée à l'exécution.
+
+Un module `.wasm` peut être distribué indépendamment de l'application hôte et chargé à l'exécution, sans aucun code `unsafe` du côté hôte.
+
+Ils nécessitent le feature flag `wasm-plugins` :
+
+```toml
+[dependencies]
+dynamic-cli = { version = "0.4.0", features = ["wasm-plugins"] }
+```
+
+### Enregistrer un plugin WASM
+
+```rust, ignore
+use dynamic_cli::CliBuilder;
+use std::path::Path;
+
+let app = CliBuilder::new()
+    .config_file("commands.yaml")
+    .context(Box::new(MyContext::default()))
+    .register_wasm_plugin(
+        Path::new("plugins/greet.wasm"),
+        &[("greet_hello", "say_hello")],
+    )?
+    .build()?;
+```
+
+### Le rôle de `function_map`
+
+`function_map` (le second argument de `register_wasm_plugin`) établit la correspondance entre deux mondes qui n'ont aucune raison de partager le même vocabulaire :
+
+- **Côté config YAML de l'application hôte** — le champ `implementation` d'une commande, exactement comme pour un plugin statique ou un handler natif.
+- **Côté module `.wasm`** — le nom réellement exporté par le binaire WASM, choisi librement par l'auteur du plugin, qui n'a probablement jamais vu la config YAML de l'application qui l'utilisera.
+
+Chaque entrée de `function_map` est donc une paire `(nom_implementation, nom_fonction_exportée_par_le_wasm)` :
+
+```rust
+&[("greet_hello", "say_hello")]
+//   ↑                ↑
+//   │                └─ nom exporté par le module .wasm (choisi par l'auteur du plugin)
+//   └─ valeur du champ `implementation` dans la config YAML de l'hôte
+```
+
+Ces deux noms n'ont **aucune obligation d'être identiques** — `greet_hello` et `say_hello` peuvent tout aussi bien être tous les deux `greet`, ou totalement différents, sans que cela change le comportement. Ce découplage est volontaire : il permet à l'auteur du plugin de nommer ses fonctions exportées selon ses propres conventions, sans devoir connaître à l'avance le nom `implementation` que choisira chaque application hôte qui l'intégrera.
+
+**Pourquoi ce paramètre est obligatoire, sans valeur par défaut.** Une table vide enregistrerait zéro handler — le plugin serait chargé avec succès (les exports obligatoires sont valides), mais resterait silencieusement inerte : aucune commande ne pourrait jamais l'atteindre. C'est précisément le genre de défaut qu'on préfère détecter à la compilation/à l'écriture du code plutôt que découvrir au runtime qu'une commande censée fonctionner ne fait rien. C'est aussi pourquoi `with_format` et `with_metadata`, qui ont des valeurs par défaut raisonnables (YAML, métadonnées dérivées du nom de fichier), restent optionnels — la différence de traitement n'est pas arbitraire, elle reflète l'absence ou la présence d'un comportement par défaut sûr.
+
+À la différence de `WasmPlugin::with_format` ou `WasmPlugin::with_metadata`, qui ont des valeurs par défaut raisonnables, une table de correspondance vide enregistrerait zéro handler — un plugin silencieusement inerte. Les applications ayant besoin d'un format de sérialisation différent du défaut ou de métadonnées explicites doivent construire un `WasmPlugin` directement et le passer à `register_plugin()` :
+
+```rust
+use dynamic_cli::plugin::wasm::{WasmPlugin, WasmSerializationFormat};
+
+let plugin = WasmPlugin::load(Path::new("plugins/greet.wasm"))?
+    .with_function_map("greet_hello", "say_hello")
+    .with_format(WasmSerializationFormat::Json)
+    .with_metadata("greet", "1.0.0", "Greeting commands");
+
+CliBuilder::new()
+    .config_file("commands.yaml")
+    .context(Box::new(MyContext::default()))
+    .register_plugin(Box::new(plugin))
+    .build()?;
+```
+
+### Le côté YAML
+
+Identique en principe à un plugin statique — la config déclare une commande avec un nom `implementation` ; ce nom doit apparaître comme premier élément d'une entrée de `function_map`, **pas** le nom de la fonction exportée par le WASM (le second élément) :
+
+```yaml
+commands:
+  - name: greet
+    implementation: greet_hello   # <- correspond au premier élément de function_map
+    description: "Greet someone"
+    arguments: []
+    options: []
+```
+
+```rust
+.register_wasm_plugin(
+    Path::new("plugins/greet.wasm"),
+    &[("greet_hello", "say_hello")],
+    //  ^ implementation       ^ nom exporté par le module .wasm
+)?
+```
+
+### Le contrat ABI côté guest
+
+C'est la partie qu'un *auteur de plugin* (la personne qui écrit le module `.wasm`, qui peut n'avoir aucune connaissance des internes Rust de `dynamic-cli`) doit implémenter.
+
+#### Exports obligatoires
+
+| Nom de l'export | Signature | Rôle |
+|---|---|---|
+| `memory` | mémoire linéaire | Tampon partagé pour le transfert des arguments et des résultats |
+| `dcli_alloc` | `(size: i32) -> i32` | L'hôte demande au guest de réserver `size` octets ; retourne le pointeur |
+| `dcli_dealloc` | `(ptr: i32, size: i32)` | L'hôte demande au guest de libérer un tampon qu'il avait précédemment alloué |
+| *(fonction métier)* | `(ptr: i32, len: i32) -> i32` | Lit les arguments sérialisés à `ptr`/`len` ; retourne `0` en cas de succès, une valeur non nulle en cas d'erreur |
+
+Le nom d'export de la fonction métier est choisi librement par l'auteur du plugin — `dynamic-cli` n'impose aucune convention de nommage sur celui-ci, au-delà des trois noms réservés ci-dessus et de l'export optionnel ci-dessous.
+
+Un module peut exporter plus d'une fonction métier ; chacune mappée à un nom `implementation` distinct dans `function_map` devient un handler de commande séparé.
+
+**Pourquoi `dcli_alloc` et `dcli_dealloc` sont tous deux obligatoires.**
+
+L'hôte ne peut pas écrire en toute sécurité dans la mémoire linéaire d'un guest à un offset arbitraire — seul le guest sait quelles régions sont libres. `dcli_alloc` permet à l'hôte de demander au guest de réserver de l'espace avant d'y écrire les arguments sérialisés.
+
+`dcli_dealloc` est obligatoire, et non optionnel, par choix délibéré. Un plugin qui alloue sans jamais libérer fuit la mémoire du guest à chaque invocation.
+
+`dynamic-cli` appelle `dcli_dealloc` sur **chaque** chemin de sortie d'un appel de handler — y compris lorsque la fonction métier elle-même retourne un code d'erreur non nul. C'est ce qui garantit qu'une session REPL longue, invoquant plusieurs fois la même commande de plugin, n'accumule jamais de tampons non libérés.
+
+#### Export optionnel
+
+| Nom de l'export | Signature | Rôle |
+|---|---|---|
+| `dcli_last_error_message` | `() -> (ptr: i32, len: i32)` | Retourne un message d'erreur détaillé lorsque la fonction métier retourne un code non nul |
+
+Lorsqu'une fonction métier retourne un code non nul, l'hôte tente d'appeler `dcli_last_error_message` pour obtenir une explication lisible.
+
+La valeur `len` retournée est lue littéralement. Si elle ne correspond pas exactement au nombre d'octets significatifs à `ptr`, la mémoire environnante — typiquement du remplissage initialisé à zéro — sera incluse dans le message.
+
+Si cet export est absent, ou si son appel échoue pour une raison quelconque, l'erreur remonte avec seulement le code brut (`message: None`). Un message absent ou illisible se dégrade proprement : il ne fait jamais échouer la commande différemment et ne s'escalade jamais en une erreur séparée.
+
+Aucun autre export optionnel n'existe dans cette version.
+
+#### Sérialisation des arguments
+
+Les arguments du handler — le `HashMap<String, String>` qu'un `CommandHandler` natif recevrait — sont sérialisés dans un tampon d'octets avant de traverser la frontière hôte/guest.
+
+**YAML est le format par défaut**, cohérent avec le principe config-first du framework. Un auteur de plugin qui préfère JSON peut le demander côté hôte via `WasmPlugin::with_format(WasmSerializationFormat::Json)` — c'est un réglage côté hôte ; le guest doit simplement être écrit pour analyser le format que l'hôte est configuré pour envoyer.
+
+Le guest reçoit le tampon sérialisé exactement comme écrit par l'hôte : aucun préfixe de longueur, aucune enveloppe — uniquement les octets bruts YAML ou JSON à `ptr`, sur `len` octets.
+
+#### Séquence d'appel
+
+Pour une seule invocation de commande, l'hôte effectue la séquence suivante sur un `Store` et une `Instance` fraîchement créés — chaque appel obtient sa propre instanciation isolée ; aucun état ne persiste entre les invocations d'un même plugin :
+
+1. Sérialiser les arguments du handler (YAML par défaut).
+2. Appeler `dcli_alloc(len)` pour obtenir un pointeur `ptr` dans la mémoire
+   du guest.
+3. Écrire les octets sérialisés dans la mémoire du guest à `ptr`.
+4. Appeler la fonction métier mappée comme `(ptr, len) -> i32`.
+5. Appeler `dcli_dealloc(ptr, len)` — inconditionnellement, quel que soit
+   le résultat de l'étape 4.
+6. Si la fonction métier a retourné `0` : la commande réussit.
+7. Si elle a retourné une valeur non nulle : tenter `dcli_last_error_message()`
+   pour un message détaillé (au mieux, voir ci-dessus), puis faire remonter
+   l'erreur à l'application hôte.
+
+#### Exemple minimal et reproductible (WAT)
+
+L'exemple suivant est volontairement écrit en WAT (WebAssembly Text format) plutôt qu'en Rust : `wasmtime::Module::new` accepte le WAT directement, sans recourir à aucun toolchain de compilation externe. C'est exactement la même approche qui valide la suite de tests d'intégration de `dynamic-cli` (`tests/integration/wasm_plugin_test.rs`) — ce module est donc garanti compatible avec le contrat ABI attendu, puisqu'il en reprend la structure éprouvée par les tests.
+
+```wat
+(module
+    (memory (export "memory") 1)
+
+    ;; Allocateur trivial : un pointeur fixe à l'offset 1024.
+    ;; Suffisant pour un exemple à appel unique ; un vrai plugin gérerait
+    ;; un tas réel si plusieurs allocations concurrentes sont possibles.
+    (func (export "dcli_alloc") (param i32) (result i32)
+        i32.const 1024)
+
+    ;; Dealloc no-op : rien à libérer avec un allocateur à pointeur fixe.
+    (func (export "dcli_dealloc") (param i32 i32))
+
+    ;; Fonction métier mappée à l'implementation "greet_hello" côté hôte.
+    ;; Ignore volontairement le contenu reçu pour rester minimal — un vrai
+    ;; plugin lirait et désérialiserait les octets à ptr/len.
+    (func (export "say_hello") (param i32 i32) (result i32)
+        i32.const 0)
+)
+```
+
+Pour le charger depuis un fichier dans une application réelle, écrire ce contenu dans `greet.wasm` (l'extension `.wasm` n'impose pas le format binaire — `wasmtime` détecte et accepte le WAT texte) :
+
+```rust
+CliBuilder::new()
+    .config_file("commands.yaml")
+    .context(Box::new(MyContext::default()))
+    .register_wasm_plugin(Path::new("greet.wasm"), &[("greet_hello", "say_hello")])?
+    .build()?;
+```
+
+#### Exemple Rust (`wasm32-unknown-unknown`) — à vérifier sur votre toolchain
+
+L'exemple suivant illustre la même logique en Rust, avec une lecture réelle des arguments sérialisés. D'autres langages capables de cibler WASM et d'exporter des fonctions compatibles ABI C (C, AssemblyScript, Zig, …) sont tout aussi valides — `dynamic-cli` n'impose aucune exigence spécifique à Rust côté guest.
+
+**Avertissement** : ce code n'a pas été compilé ni exécuté dans le cadre de la rédaction de ce guide — il illustre l'approche standard (allocateur via `Box::into_raw`/`Box::from_raw`, lecture via `std::slice::from_raw_parts`) mais doit être vérifié par compilation réelle avant d'être utilisé en production.
+
+```rust
+// Cargo.toml du plugin :
+//   [lib]
+//   crate-type = ["cdylib"]
+//   [dependencies]
+//   serde = { version = "1.0", features = ["derive"] }
+//   serde_yaml = "0.9"
+
+#[no_mangle]
+pub extern "C" fn dcli_alloc(size: i32) -> i32 {
+    let buf = vec![0u8; size as usize].into_boxed_slice();
+    Box::into_raw(buf) as *mut u8 as i32
+}
+
+#[no_mangle]
+pub extern "C" fn dcli_dealloc(ptr: i32, size: i32) {
+    unsafe {
+        let slice = std::slice::from_raw_parts_mut(ptr as *mut u8, size as usize);
+        drop(Box::from_raw(slice as *mut [u8]));
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn say_hello(ptr: i32, len: i32) -> i32 {
+    let bytes = unsafe { std::slice::from_raw_parts(ptr as *const u8, len as usize) };
+    let args: std::collections::HashMap<String, String> = match serde_yaml::from_slice(bytes) {
+        Ok(a) => a,
+        Err(_) => return 1,
+    };
+    let name = args.get("name").cloned().unwrap_or_else(|| "World".to_string());
+    println!("Hello, {name}!");
+    0
+}
+```
+
+Compilation vers `wasm32-unknown-unknown` :
+
+```bash
+rustup target add wasm32-unknown-unknown
+cargo build --release --target wasm32-unknown-unknown
+# Le binaire produit se trouve sous :
+#   target/wasm32-unknown-unknown/release/<nom_du_crate>.wasm
+```
+
+Avant de livrer le plugin, vérifiez que les exports attendus sont bien présents dans le binaire compilé — par exemple avec `wasm-objdump -x` (paquet `wabt`) ou tout outil d'introspection WASM équivalent : `memory`, `dcli_alloc`, `dcli_dealloc`, et la fonction métier choisie doivent apparaître dans la liste des exports.
+
+**Remarque sur `dcli_last_error_message`.** `dynamic-cli` appelle cet export comme une véritable fonction WASM à valeurs de retour multiples, retournant deux résultats `i32` — équivalent à cette signature WAT :
+
+```wat
+(func (export "dcli_last_error_message") (result i32 i32)
+    ;; empiler ptr, puis len, dans cet ordre
+    ...)
+```
+
+Les fonctions `extern "C"` ordinaires en Rust compilées vers `wasm32-unknown-unknown` ne peuvent pas exprimer de façon portable un véritable retour multi-valeurs à deux `i32` selon toutes les versions de toolchain — les schémas d'encodage qui compactent les deux valeurs dans un seul `i64` ne sont **pas** compatibles avec ce contrat ; `dynamic-cli` appelle l'export en attendant exactement deux résultats `i32` séparés, pas une valeur compactée. Vérifiez le code généré réel par votre toolchain (par exemple en inspectant le `.wasm` compilé avec `wasm-objdump` ou les outils d'introspection propres à `wasmtime`) avant de livrer un plugin qui repose sur cet export optionnel. Si votre toolchain ne peut pas l'exprimer de façon fiable, omettez l'export — l'erreur remontera simplement avec `message: None`, le repli documenté et sans danger.
+
+---
+
+## Détection de conflit
+
+`CliBuilder::build()` fusionne les handlers de chaque plugin statique, les handlers mappés de chaque plugin WASM, et chaque handler enregistré directement dans une seule table interne, indexée par nom `implementation`.
+
+Si deux sources revendiquent le même nom, `build()` retourne une erreur identifiant le plugin et le nom en cause, avec une suggestion de renommer soit le nom `implementation` en conflit dans la config YAML, soit de retirer l'appel d'enregistrement en double.
+
+Ceci s'applique de façon uniforme quel que soit le mécanisme utilisé par chaque côté. Un plugin statique entrant en collision avec le nom mappé d'un plugin WASM est détecté exactement comme deux plugins statiques entrant en collision entre eux.
+
+---
+
+## Restrictions et limitations (plugins WASM)
+
+Cette section distingue deux catégories de nature différente.
+
+Une **restriction** est un choix structurel délibéré, motivé par la sécurité du modèle de sandbox. Elle ne changera pas — la lever reviendrait à abandonner la garantie d'isolation que les plugins WASM sont censés apporter.
+
+Une **limitation** est une absence de fonctionnalité dans la version actuelle, sans obstacle de principe à son ajout futur. Elle pourrait évoluer un jour, ou ne jamais être traitée si aucun besoin concret ne se présente — aucun engagement n'est pris dans un sens ou dans l'autre.
+
+### Restriction — aucun accès à `ExecutionContext`
+
+Les handlers WASM ne reçoivent **pas** l'`ExecutionContext` de l'application hôte.
+
+C'est une frontière délibérée, pas un oubli. Les trait objects ne peuvent pas traverser la frontière FFI de WASM. Exposer un état arbitraire de l'hôte à un guest sandboxé irait par ailleurs à l'encontre du but même de la sandbox.
+
+Les plugins WASM de cette version n'échangent donc que des arguments sérialisés et un code de résultat accompagné d'un message optionnel — rien d'autre.
+
+Concrètement : un plugin WASM ne peut pas lire ni écrire l'état en mémoire de l'application hôte. Il ne peut pas accéder à ce que l'`ExecutionContext` de l'hôte enveloppe — une connexion base de données, un objet de session, etc. Il n'a aucun moyen de rappeler un comportement défini côté hôte.
+
+Cette restriction ne sera pas levée dans une future version sans remettre en cause le modèle de sandbox lui-même.
+
+### Limitation — aucune fonction hôte, aucun WASI
+
+Cette version n'expose aucune fonction définie par l'hôte au guest : pas de `host_log`, pas de `host_get_state`, rien d'importé par le module au-delà de ce que WASM fournit lui-même. Elle ne câble pas non plus WASI.
+
+Un plugin WASM est, en pratique, une fonction pure allant d'arguments sérialisés à un code de résultat et un message optionnel. Il ne peut effectuer aucune E/S, aucune journalisation, ni aucune interaction avec le monde extérieur à travers `dynamic-cli` lui-même.
+
+Contrairement à la restriction précédente, ceci n'est pas un principe de sécurité — c'est simplement ce qui n'a pas encore été construit. Voir les pistes ci-dessous.
+
+### Pistes d'évolution envisageables pour les limitations
+
+Ce ne sont pas des engagements, et aucune n'est planifiée pour le cycle en cours.
+
+**Fonctions hôte restreintes** — exposer un petit ensemble explicite de fonctions définies par l'hôte (par exemple `host_log`, `host_get_state`/`host_set_state`) qu'un guest pourrait importer. Ça donnerait un accès contrôlé aux capacités de l'hôte sans rompre le modèle de sandbox.
+
+**Déclaration de capacités** — un plugin déclarant en amont les capacités dont il a besoin (accès fichier, réseau, état partagé), l'hôte n'exposant que les fonctions hôte correspondantes. Ça préserverait les propriétés de sécurité du modèle de sandbox même à mesure que les capacités s'étendent.
+
+**Intégration WASI** — via `wasmtime-wasi`, pour les plugins qui ont réellement besoin d'un accès standardisé et auditable au système de fichiers ou au réseau.
+
+Chacune de ces pistes constituerait une nouvelle décision explicitement versionnée, pas une extension silencieuse du contrat actuel.
+
+---
+
+## Références associées
+
+- Issue [#10](https://github.com/biface/dcli/issues/10) — la décision
+  architecturale derrière les plugins statiques (Option A) et WASM
+  (Option C), et l'exclusion définitive du chargement dynamique via
+  `libloading` (Option B).
+- `src/plugin/mod.rs` (rustdoc) — le trait `Plugin`, référence API complète.
+- `src/plugin/system.rs` (rustdoc) — `SystemPlugin`, une implémentation de
+  référence complète.
+- `src/plugin/wasm.rs` (rustdoc) — `WasmPlugin`, `WasmSerializationFormat`,
+  l'API Rust du loader WASM.
+- [`CONFIG_SYNTAX_REFERENCE.md`](CONFIG_SYNTAX_REFERENCE.md) — syntaxe
+  complète de configuration YAML des commandes.

--- a/PLUGIN_GUIDE.md
+++ b/PLUGIN_GUIDE.md
@@ -1,0 +1,801 @@
+# Plugin Design Guide — `dynamic-cli`
+
+> Getting started with building and registering plugins for a third-party
+> application using the `dynamic-cli` crate.
+
+* Decision context:
+  * Design decision (plugin system architecture) [DD-021](https://github.com/biface/dcli/issues/10)
+  * Static plugin implementation: [`Plugin` trait](https://github.com/biface/dcli/issues/22)
+  * Sandboxed WASM plugin implementation: [`WasmPlugin`](https://github.com/biface/dcli/issues/23)
+* **Last updated**: 2026-06-17 (v0.4.0)
+
+---
+
+## Overview
+
+`dynamic-cli` offers two ways to extend an application with handlers that do not live in the host application's own crate:
+
+| Mechanism | When to use it | Cost |
+|---|---|---|
+| **Static plugins** (`Plugin` trait) | The plugin's code is compiled into the host binary | No `unsafe`, no extra dependency, no runtime overhead |
+| **WASM plugins** (`WasmPlugin`) | The plugin must be distributed and loaded independently of the host binary, or run in a sandbox | `wasmtime` dependency (opt-in via `features = ["wasm-plugins"]`), guest-side ABI contract to implement |
+
+A third option was considered and **permanently excluded**: dynamically loading native libraries via `libloading`. Rust's ABI is not stable across compiler versions, which makes this approach structurally unsafe regardless of implementation quality.
+
+Both supported mechanisms share the same architectural principle, inherited from the framework's "config-first" design: **the YAML configuration remains the sole source of truth for command definitions.**
+
+In other words, a plugin — static or WASM — never declares its own commands. It only supplies the *handler* for a command the host application has already declared in its YAML configuration.
+
+---
+
+## The common YAML contract
+
+Whether a handler comes from a static plugin, a WASM plugin, or a direct call to `CliBuilder::register_handler()`, each follows the same registration formalism in the YAML configuration file.
+
+A command entry names an `implementation`, and *something* must supply a handler under that exact name by the time `CliBuilder::build()` runs. For more on the YAML configuration, see [The configuration syntax](CONFIG_SYNTAX_REFERENCE.md).
+
+```yaml
+commands:
+  - name: greet
+    description: "Greet someone"
+    implementation: greet_hello   # <- this is the key a plugin must match
+    arguments: []
+    options: []
+```
+
+`build()` does not care where `greet_hello` comes from. Whether it comes from a static plugin's `Plugin::handlers()`, a WASM plugin's mapped business function, or a directly registered `Box<dyn CommandHandler>`, all are merged into the same internal resolution table before commands are resolved.
+
+This also makes it possible to combine multiple mechanisms within the same application: a `SystemPlugin` for `help`/`version`/`exit`, a WASM plugin for a sandboxed third-party command, and a hand-written native handler for the application's core business logic can all coexist — as long as none of these mechanisms claims the same `implementation` name.
+
+If two sources attempt to supply the same `implementation` name, `build()` fails with an explicit conflict error rather than letting one silently overwrite the other. See [Conflict detection](#conflict-detection) below.
+
+---
+
+## Static plugins
+
+### The `Plugin` trait
+
+```rust
+pub trait Plugin: Send + Sync {
+    fn name(&self) -> &str;
+    fn version(&self) -> &str;
+    fn description(&self) -> &str;
+    fn handlers(&self) -> Vec<(String, Box<dyn CommandHandler>)>;
+}
+```
+
+A plugin declares metadata — `name`, `version`, `description`, used for introspection, for example listing loaded plugins — and the handlers it supplies, each tagged with the `implementation` name it must match.
+
+The trait is deliberately *declarative*: a plugin returns its handlers; it does not receive a `&mut CommandRegistry` to register them itself.
+
+This keeps registration control on the framework's side, not the plugin's. It is exactly the same pattern `CommandHandler` itself follows: a handler declares its execution logic, the framework decides when to invoke it.
+
+This also lets the framework validate every handler name before any of them touches the registry — which is what makes clean conflict detection possible (see below) instead of letting a plugin silently overwrite an existing command.
+
+### Registering a static plugin
+
+```rust
+use dynamic_cli::CliBuilder;
+use dynamic_cli::plugin::SystemPlugin;
+
+let app = CliBuilder::new()
+    .config_file("commands.yaml")
+    .context(Box::new(MyContext::default()))
+    .register_plugin(Box::new(SystemPlugin::new()))
+    .build()?;
+```
+
+`register_plugin()` can be called multiple times, and freely combined with `register_handler()` for handlers that do not come from a plugin.
+
+### `SystemPlugin` — the reference implementation
+
+`dynamic-cli` ships a ready-to-use static plugin: [`SystemPlugin`](../src/plugin/system.rs), which supplies the three commands almost every application needs:
+
+| `implementation` name | Behaviour |
+|---|---|
+| `system_help` | Prints application or per-command help via the active `HelpFormatter` |
+| `system_version` | Prints the version from the config's `metadata.version` |
+| `system_exit` | Runs a shutdown callback, then exits |
+
+```yaml
+commands:
+  - name: help
+    implementation: system_help
+    aliases: ["h", "?"]
+    description: "Show help"
+    arguments: []
+    options: []
+
+  - name: version
+    implementation: system_version
+    description: "Show version"
+    arguments: []
+    options: []
+
+  - name: exit
+    implementation: system_exit
+    aliases: ["quit", "q"]
+    description: "Exit the application"
+    arguments: []
+    options: []
+```
+
+```rust
+CliBuilder::new()
+    .config_file("commands.yaml")
+    .context(Box::new(MyContext::default()))
+    .register_plugin(Box::new(SystemPlugin::new()))
+    .build()?
+    .run()
+```
+
+#### Shutdown callback
+
+The default behaviour of `system_exit` is `std::process::exit(0)`. An application that needs a clean shutdown sequence — flushing logs, closing connections, persisting state — can supply its own callback:
+
+```rust
+SystemPlugin::new()
+    .with_exit_fn(|| {
+        eprintln!("Saving session…");
+        // close resources here
+        std::process::exit(0);
+    })
+```
+
+The callback runs before the process terminates; it is the application's responsibility to actually exit at the end of it.
+
+### Writing your own static plugin
+
+A static plugin is any type that implements `Plugin`. No scaffolding or macro is required — see the rustdoc of `src/plugin/mod.rs` for a complete minimal example, and `src/plugin/system.rs` for a plugin with multiple handlers and constructor-supplied configuration (`with_config`, `with_exit_fn`).
+
+#### Concrete example — a diagnostics plugin for `chrom-rs`
+
+`chrom-rs` is a liquid chromatography simulation application. Its scenarios are driven by three independent YAML files (`model.yml`, `scenario.yml`, `solver.yml`) consumed by the `chrom-rs run` command.
+
+Before running a potentially long simulation — RK4 over several thousand time points — it is useful to be able to validate the consistency of the three files without running the solver.
+
+The example below follows `chrom-rs`'s actual structure: its `ExecutionContext` (`ChromContext`, which carries a validated `project_dir`), the downcast pattern used by `RunHandler`, and the option schema as defined in `commands.yml`.
+
+The plugin lives in its own file, next to `app.rs`, as a new submodule of `src/cli/`:
+
+```
+src/cli/
+    mod.rs           — build_app(), orchestration (existing)
+    app.rs           — ChromContext, RunHandler (existing)
+    diagnostics.rs   — DiagnosticsPlugin, ValidateConfigHandler (new)
+```
+
+`src/cli/diagnostics.rs`:
+
+```rust
+use dynamic_cli::plugin::Plugin;
+use dynamic_cli::executor::CommandHandler;
+use dynamic_cli::context::ExecutionContext;
+use dynamic_cli::error::ExecutionError;
+use dynamic_cli::DynamicCliError;
+use std::collections::HashMap;
+
+use crate::cli::app::ChromContext;
+
+/// Diagnostics plugin for chrom-rs: checks that the configuration files
+/// are present before a costly run.
+struct DiagnosticsPlugin;
+
+impl Plugin for DiagnosticsPlugin {
+    fn name(&self) -> &str { "chrom-diagnostics" }
+    fn version(&self) -> &str { "1.0.0" }
+    fn description(&self) -> &str {
+        "Validates model/scenario/solver files before simulation"
+    }
+
+    fn handlers(&self) -> Vec<(String, Box<dyn CommandHandler>)> {
+        vec![
+            ("validate_config".to_string(), Box::new(ValidateConfigHandler)),
+        ]
+    }
+}
+
+struct ValidateConfigHandler;
+
+impl CommandHandler for ValidateConfigHandler {
+    fn execute(
+        &self,
+        ctx: &mut dyn ExecutionContext,
+        args: &HashMap<String, String>,
+    ) -> dynamic_cli::Result<()> {
+        // Same downcast pattern as RunHandler (src/cli/app.rs): the
+        // plugin needs the project_dir already validated by ChromContext,
+        // not a raw path.
+        let chrom_ctx = ctx
+            .as_any_mut()
+            .downcast_mut::<ChromContext>()
+            .ok_or_else(|| {
+                DynamicCliError::from(ExecutionError::ContextDowncastFailed {
+                    expected_type: "ChromContext".to_string(),
+                    suggestion: None,
+                })
+            })?;
+
+        let project_dir = chrom_ctx.project_dir();
+
+        // The default values ("model.yml", "scenario.yml", "solver.yml")
+        // are now carried by `default:` in commands.yml and already
+        // applied by the parser before this handler runs
+        // (`CliParser::apply_defaults`) — args.get() should therefore
+        // never return None here as long as the YAML stays consistent
+        // with the declared command. The fallback below remains
+        // defensive, not strictly necessary in normal use.
+        let model = args.get("model").map(String::as_str).unwrap_or("model.yml");
+        let scenario = args.get("scenario").map(String::as_str).unwrap_or("scenario.yml");
+        let solver = args.get("solver").map(String::as_str).unwrap_or("solver.yml");
+
+        for (label, file) in [("model", model), ("scenario", scenario), ("solver", solver)] {
+            let path = project_dir.join(file);
+            if !path.is_file() {
+                println!("✗ {label}: file not found ({})", path.display());
+            } else {
+                println!("✓ {label}: {}", path.display());
+            }
+        }
+
+        // A real implementation would push validation further: chemical
+        // species consistency between model.yml and scenario.yml, domain
+        // bounds compatible with the solver configuration.
+        Ok(())
+    }
+}
+```
+
+Here is the complete `commands.yml` for `chrom-rs`, with the plugin's `validate-config` command integrated next to the existing `run` command (every field — `short`, `long`, `option_type`, `default`, `choices` — is required by the schema; see [`CONFIG_SYNTAX_REFERENCE.md`](CONFIG_SYNTAX_REFERENCE.md)):
+
+```yaml
+metadata:
+  version: "0.2.0"
+  prompt: "chrom-rs"
+  prompt_suffix: " > "
+
+commands:
+  - name: run
+    aliases:
+      - simulate
+    description: "Run a chromatography simulation from three configuration files."
+    required: true
+    arguments: []
+    options:
+      - name: project-dir
+        short: "d"
+        long: project-dir
+        option_type: path
+        required: false
+        default: "."
+        description: "Root directory for all file names (no '..' allowed)."
+        choices: []
+
+      - name: model
+        short: "m"
+        long: model
+        option_type: string
+        required: true
+        default: ~
+        description: "Model configuration file (e.g. model.yml)."
+        choices: []
+
+      - name: scenario
+        short: "s"
+        long: scenario
+        option_type: string
+        required: true
+        default: ~
+        description: "Scenario configuration file (e.g. scenario.yml)."
+        choices: []
+
+      - name: solver
+        short: "S"
+        long: solver
+        option_type: string
+        required: true
+        default: ~
+        description: "Solver configuration file (e.g. solver.yml)."
+        choices: []
+
+      - name: output-csv
+        short: ~
+        long: output-csv
+        option_type: path
+        required: false
+        default: ~
+        description: "Write simulation results to a CSV file."
+        choices: []
+
+      - name: output-plot
+        short: ~
+        long: output-plot
+        option_type: path
+        required: false
+        default: ~
+        description: "Save chromatogram plot to a PNG or SVG file."
+        choices: []
+
+      - name: export-json
+        short: ~
+        long: export-json
+        option_type: path
+        required: false
+        default: ~
+        description: "Export full simulation result to a JSON file."
+        choices: []
+
+    implementation: run_handler
+
+  # ──────────────────────────────────────────────────────────────────────
+  # New command — supplied by DiagnosticsPlugin (src/cli/diagnostics.rs)
+  # See PLUGIN_GUIDE.md, "Static plugins" section.
+  # ──────────────────────────────────────────────────────────────────────
+  - name: validate-config
+    aliases:
+      - check
+    description: "Validates that model/scenario/solver files are present before simulation."
+    required: false
+    arguments: []
+    options:
+      - name: project-dir
+        short: "d"
+        long: project-dir
+        option_type: path
+        required: false
+        default: "."
+        description: "Root directory for all file names (no '..' allowed)."
+        choices: []
+
+      - name: model
+        short: "m"
+        long: model
+        option_type: string
+        required: false
+        default: "model.yml"
+        description: "Model configuration file (e.g. model.yml)."
+        choices: []
+
+      - name: scenario
+        short: "s"
+        long: scenario
+        option_type: string
+        required: false
+        default: "scenario.yml"
+        description: "Scenario configuration file (e.g. scenario.yml)."
+        choices: []
+
+      - name: solver
+        short: "S"
+        long: solver
+        option_type: string
+        required: false
+        default: "solver.yml"
+        description: "Solver configuration file (e.g. solver.yml)."
+        choices: []
+
+    implementation: validate_config
+
+global_options: []
+```
+
+The `run` block is unchanged from the original file — only the `validate-config` block is new, added by the plugin. The `project-dir`/`model`/`scenario`/`solver` options deliberately reuse the same shorts (`-d`/`-m`/`-s`/`-S`) as `run`: each command has its own namespace for its short options, so no collision is possible between two different commands.
+
+And the registration, in `chrom-rs`'s `src/cli/mod.rs`, next to `RunHandler`. Two additions compared to the existing file: the new submodule declaration, and the `register_plugin` call in `build_app`:
+
+```rust
+// New, next to `pub mod app;`
+pub mod diagnostics;
+
+use app::{ChromContext, RunHandler};
+use diagnostics::DiagnosticsPlugin;
+
+pub fn build_app() -> anyhow::Result<CliApp> {
+    let config =
+        load_yaml(COMMANDS_YML).map_err(|e| anyhow!("embedded commands.yml is invalid: {e}"))?;
+
+    CliBuilder::new()
+        .config(config)
+        .context(Box::new(ChromContext::new()))
+        .register_handler(RUN_HANDLER_NAME, Box::new(RunHandler))
+        .register_plugin(Box::new(DiagnosticsPlugin))
+        .build()
+        .map_err(|e| anyhow!("CLI builder error: {e}"))
+}
+```
+
+This plugin coexists with `chrom-rs`'s own `run` command — a native handler, not a plugin — without any interference. This is exactly the coexistence scenario described in [the common YAML contract](#the-common-yaml-contract) above: `run_handler` (native) and `validate_config` (plugin) are merged into the same table by `build()`.
+
+---
+
+## WASM plugins
+
+### The concept
+
+#### Who is the host, who is the guest
+
+Three distinct actors are involved, and it is important not to confuse them.
+
+`dynamic-cli` is a library. It never runs on its own — it is compiled inside the binary of a third-party application, such as `chrom-rs`.
+
+It is this **third-party application, with `dynamic-cli` compiled into it**, that constitutes the **host**. The host is therefore the process that actually runs on the end user's machine — `dynamic-cli` is only part of that process's code, not the process itself.
+
+The **guest** is the `.wasm` module loaded by that host. It runs inside a sandbox provided by `wasmtime`, itself called from `dynamic-cli`'s code.
+
+```mermaid
+graph LR
+    subgraph Host process
+        A["Third-party application<br/>(e.g. chrom-rs)"] --> B["dynamic-cli<br/>(library)"]
+        B --> C["wasmtime<br/>(runtime)"]
+    end
+    C -.->|sandbox| D["Module .wasm<br/>(guest)"]
+```
+
+When this guide uses "the host" in the WASM context, it therefore refers to `dynamic-cli`'s code acting on behalf of the application that uses it — not the application itself in the sense of its business logic, and certainly not the guest.
+
+#### Why a sandbox
+
+A WASM plugin is a binary module (`.wasm`) compiled separately from `dynamic-cli` and from the host application.
+
+Unlike a static plugin — which shares the host process's memory space — a WASM plugin runs in its own isolated linear memory space.
+
+The host cannot directly read from or write to the guest's memory. The guest cannot access the host's memory either. All data exchange goes through an explicit protocol — allocated on the guest side, written by the host, read by the guest — rather than through direct sharing of Rust structures.
+
+This isolation has a cost: serializing arguments, allocating and freeing memory on every call.
+
+It also has a payoff: the plugin can be written in any language capable of targeting WASM, distributed as a simple binary file independently of the host application's binary, and loaded without recompiling the latter.
+
+### How it is implemented in `dynamic-cli`
+
+```mermaid
+sequenceDiagram
+    participant App as Host application
+    participant Builder as CliBuilder
+    participant Handler as WasmHandler
+    participant Store as wasmtime::Store/Instance
+    participant Guest as .wasm module (sandbox)
+
+    App->>Builder: register_wasm_plugin(path, function_map)
+    Builder->>Builder: WasmPlugin::load() — checks memory,<br/>dcli_alloc, dcli_dealloc
+
+    Note over App,Guest: --- On command execution ---
+
+    App->>Handler: execute(ctx, args)
+    Handler->>Handler: Serialize args (YAML by default)
+    Handler->>Store: new Store + Instance (fresh, isolated)
+    Handler->>Guest: dcli_alloc(len) -> ptr
+    Handler->>Guest: memory.write(ptr, buffer)
+    Handler->>Guest: business_fn(ptr, len) -> code
+    Handler->>Guest: dcli_dealloc(ptr, len)  [always called]
+
+    alt code == 0
+        Guest-->>Handler: success
+        Handler-->>App: Ok(())
+    else code != 0
+        Handler->>Guest: dcli_last_error_message() [if exported]
+        Guest-->>Handler: (ptr, len) of the message, or nothing
+        Handler-->>App: Err(WasmError::GuestError)
+    end
+```
+
+Three structural points stand out from this diagram.
+
+**Loading and execution are two distinct phases.** `WasmPlugin::load` validates the mandatory exports once, at load time — not on every command call.
+
+**Each call gets its own `Store`/`Instance`.** No state persists between two invocations of the same command. This is deliberate: it guarantees isolation and avoids state leaks between calls.
+
+**`dcli_dealloc` is called on every exit path**, including when the guest errors out. This is what guarantees that a long-running REPL session does not accumulate unfreed guest memory.
+
+### Enabling the mechanism
+
+WASM plugins trade the compile-time coupling of static plugins for a sandboxed execution at runtime.
+
+A `.wasm` module can be distributed independently of the host application and loaded at runtime, with no `unsafe` code on the host side.
+
+They require the `wasm-plugins` feature flag:
+
+```toml
+[dependencies]
+dynamic-cli = { version = "0.4.0", features = ["wasm-plugins"] }
+```
+
+### Registering a WASM plugin
+
+```rust
+use dynamic_cli::CliBuilder;
+use std::path::Path;
+
+let app = CliBuilder::new()
+    .config_file("commands.yaml")
+    .context(Box::new(MyContext::default()))
+    .register_wasm_plugin(
+        Path::new("plugins/greet.wasm"),
+        &[("greet_hello", "say_hello")],
+    )?
+    .build()?;
+```
+
+### The role of `function_map`
+
+`function_map` (the second argument of `register_wasm_plugin`) establishes the correspondence between two worlds that have no reason to share the same vocabulary:
+
+- **On the host application's YAML config side** — the `implementation` field of a command, exactly as for a static plugin or a native handler.
+- **On the `.wasm` module side** — the name actually exported by the WASM binary, chosen freely by the plugin author, who has probably never seen the YAML config of the application that will use it.
+
+Each `function_map` entry is therefore a pair `(implementation_name, wasm_exported_function_name)`:
+
+```rust
+&[("greet_hello", "say_hello")]
+//   ↑                ↑
+//   │                └─ name exported by the .wasm module (chosen by the plugin author)
+//   └─ value of the `implementation` field in the host's YAML config
+```
+
+These two names are **under no obligation to be identical** — `greet_hello` and `say_hello` could just as well both be `greet`, or be entirely different, without changing the behaviour. This decoupling is intentional: it lets the plugin author name their exported functions according to their own conventions, without needing to know in advance the `implementation` name each host application will choose.
+
+**Why this parameter is mandatory, with no default.** An empty table would register zero handlers — the plugin would load successfully (the mandatory exports are valid), but would remain silently inert: no command could ever reach it. This is exactly the kind of defect best caught at compile time / while writing the code, rather than discovered at runtime when a command that is supposed to work does nothing. This is also why `with_format` and `with_metadata`, which have reasonable defaults (YAML, file-name-derived metadata), remain optional — the difference in treatment is not arbitrary; it reflects the presence or absence of a safe default behaviour.
+
+Applications needing a non-default serialization format or explicit metadata should build a `WasmPlugin` directly and pass it to `register_plugin()`:
+
+```rust
+use dynamic_cli::plugin::wasm::{WasmPlugin, WasmSerializationFormat};
+
+let plugin = WasmPlugin::load(Path::new("plugins/greet.wasm"))?
+    .with_function_map("greet_hello", "say_hello")
+    .with_format(WasmSerializationFormat::Json)
+    .with_metadata("greet", "1.0.0", "Greeting commands");
+
+CliBuilder::new()
+    .config_file("commands.yaml")
+    .context(Box::new(MyContext::default()))
+    .register_plugin(Box::new(plugin))
+    .build()?;
+```
+
+### The YAML side
+
+In principle identical to a static plugin — the config declares a command with an `implementation` name; that name must appear as the first element of a `function_map` entry, **not** the name of the function exported by the WASM module (the second element):
+
+```yaml
+commands:
+  - name: greet
+    implementation: greet_hello   # <- matches function_map's first element
+    description: "Greet someone"
+    arguments: []
+    options: []
+```
+
+```rust
+.register_wasm_plugin(
+    Path::new("plugins/greet.wasm"),
+    &[("greet_hello", "say_hello")],
+    //  ^ implementation       ^ name exported by the .wasm module
+)?
+```
+
+### The guest-side ABI contract
+
+This is the part a *plugin author* (the person writing the `.wasm` module, who may have no knowledge of `dynamic-cli`'s Rust internals) needs to implement.
+
+#### Mandatory exports
+
+| Export name | Signature | Purpose |
+|---|---|---|
+| `memory` | linear memory | Shared buffer for argument and result transfer |
+| `dcli_alloc` | `(size: i32) -> i32` | Host asks the guest to reserve `size` bytes; returns the pointer |
+| `dcli_dealloc` | `(ptr: i32, size: i32)` | Host asks the guest to free a buffer it had previously allocated |
+| *(business function)* | `(ptr: i32, len: i32) -> i32` | Reads serialized arguments at `ptr`/`len`; returns `0` on success, a non-zero value on error |
+
+The business function's exported name is chosen freely by the plugin author — `dynamic-cli` imposes no naming convention on it, beyond the three reserved names above and the optional export below.
+
+A module may export more than one business function; each one mapped to a distinct `implementation` name in `function_map` becomes a separate command handler.
+
+**Why `dcli_alloc` and `dcli_dealloc` are both mandatory.**
+
+The host cannot safely write into a guest's linear memory at an arbitrary offset — only the guest knows which regions are free. `dcli_alloc` lets the host ask the guest to reserve space before writing the serialized arguments into it.
+
+`dcli_dealloc` is mandatory, not optional, by deliberate choice. A plugin that allocates without ever freeing leaks guest memory on every invocation.
+
+`dynamic-cli` calls `dcli_dealloc` on **every** exit path of a handler call — including when the business function itself returns a non-zero error code. This is what guarantees that a long-running REPL session, repeatedly invoking the same plugin command, never accumulates unfreed buffers.
+
+#### Optional export
+
+| Export name | Signature | Purpose |
+|---|---|---|
+| `dcli_last_error_message` | `() -> (ptr: i32, len: i32)` | Returns a detailed error message when the business function returns a non-zero code |
+
+When a business function returns a non-zero code, the host attempts to call `dcli_last_error_message` to obtain a human-readable explanation.
+
+The returned `len` value is read literally. If it does not exactly match the number of meaningful bytes at `ptr`, surrounding memory — typically zero-initialized padding — will be included in the message.
+
+If this export is absent, or if calling it fails for any reason, the error surfaces with only the raw code (`message: None`). A missing or unreadable message degrades gracefully: it never causes the command to fail differently, and never escalates into a separate error.
+
+No other optional export exists in this version.
+
+#### Argument serialization
+
+Handler arguments — the `HashMap<String, String>` a native `CommandHandler` would receive — are serialized into a byte buffer before crossing the host/guest boundary.
+
+**YAML is the default format**, consistent with the framework's config-first principle. A plugin author who prefers JSON can request it on the host side via `WasmPlugin::with_format(WasmSerializationFormat::Json)` — this is a host-side setting; the guest simply needs to be written to parse whichever format the host is configured to send.
+
+The guest receives the serialized buffer exactly as written by the host: no length prefix, no envelope — just the raw YAML or JSON bytes at `ptr`, `len` bytes long.
+
+#### Call sequence
+
+For a single command invocation, the host performs the following sequence on a freshly created `Store` and `Instance` — each call gets its own isolated instantiation; no state persists between invocations of the same plugin:
+
+1. Serialize the handler's arguments (YAML by default).
+2. Call `dcli_alloc(len)` to obtain a pointer `ptr` into guest memory.
+3. Write the serialized bytes into guest memory at `ptr`.
+4. Call the mapped business function as `(ptr, len) -> i32`.
+5. Call `dcli_dealloc(ptr, len)` — unconditionally, regardless of step 4's
+   outcome.
+6. If the business function returned `0`: the command succeeds.
+7. If it returned a non-zero value: attempt `dcli_last_error_message()`
+   for a detailed message (best-effort, see above), then surface the
+   error to the host application.
+
+#### Minimal, reproducible example (WAT)
+
+The following example is deliberately written in WAT (WebAssembly Text format) rather than in Rust: `wasmtime::Module::new` accepts WAT directly, with no external compilation toolchain required. This is exactly the same approach used to validate `dynamic-cli`'s integration test suite (`tests/integration/wasm_plugin_test.rs`) — this module is therefore guaranteed compatible with the expected ABI contract, since it follows the structure proven by the tests.
+
+```wat
+(module
+    (memory (export "memory") 1)
+
+    ;; Trivial allocator: a fixed pointer at offset 1024.
+    ;; Sufficient for a single-call example; a real plugin would manage
+    ;; an actual heap if concurrent allocations are possible.
+    (func (export "dcli_alloc") (param i32) (result i32)
+        i32.const 1024)
+
+    ;; No-op dealloc: nothing to free with a fixed-pointer allocator.
+    (func (export "dcli_dealloc") (param i32 i32))
+
+    ;; Business function mapped to the "greet_hello" implementation on
+    ;; the host side. Deliberately ignores the received content to stay
+    ;; minimal — a real plugin would read and deserialize the bytes at
+    ;; ptr/len.
+    (func (export "say_hello") (param i32 i32) (result i32)
+        i32.const 0)
+)
+```
+
+To load it from a file in a real application, write this content into `greet.wasm` (the `.wasm` extension does not enforce the binary format — `wasmtime` detects and accepts plain-text WAT):
+
+```rust
+CliBuilder::new()
+    .config_file("commands.yaml")
+    .context(Box::new(MyContext::default()))
+    .register_wasm_plugin(Path::new("greet.wasm"), &[("greet_hello", "say_hello")])?
+    .build()?;
+```
+
+#### Rust example (`wasm32-unknown-unknown`) — verify on your toolchain
+
+The following example illustrates the same logic in Rust, with an actual read of the serialized arguments. Other languages capable of targeting WASM and exporting C ABI-compatible functions (C, AssemblyScript, Zig, …) are equally valid — `dynamic-cli` imposes no Rust-specific requirement on the guest side.
+
+**Warning**: this code has not been compiled or run as part of writing this guide — it illustrates the standard approach (allocator via `Box::into_raw`/`Box::from_raw`, reading via `std::slice::from_raw_parts`) but must be verified by an actual build before being used in production.
+
+```rust
+// Plugin's Cargo.toml:
+//   [lib]
+//   crate-type = ["cdylib"]
+//   [dependencies]
+//   serde = { version = "1.0", features = ["derive"] }
+//   serde_yaml = "0.9"
+
+#[no_mangle]
+pub extern "C" fn dcli_alloc(size: i32) -> i32 {
+    let buf = vec![0u8; size as usize].into_boxed_slice();
+    Box::into_raw(buf) as *mut u8 as i32
+}
+
+#[no_mangle]
+pub extern "C" fn dcli_dealloc(ptr: i32, size: i32) {
+    unsafe {
+        let slice = std::slice::from_raw_parts_mut(ptr as *mut u8, size as usize);
+        drop(Box::from_raw(slice as *mut [u8]));
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn say_hello(ptr: i32, len: i32) -> i32 {
+    let bytes = unsafe { std::slice::from_raw_parts(ptr as *const u8, len as usize) };
+    let args: std::collections::HashMap<String, String> = match serde_yaml::from_slice(bytes) {
+        Ok(a) => a,
+        Err(_) => return 1,
+    };
+    let name = args.get("name").cloned().unwrap_or_else(|| "World".to_string());
+    println!("Hello, {name}!");
+    0
+}
+```
+
+Compiling to `wasm32-unknown-unknown`:
+
+```bash
+rustup target add wasm32-unknown-unknown
+cargo build --release --target wasm32-unknown-unknown
+# The resulting binary is found at:
+#   target/wasm32-unknown-unknown/release/<crate_name>.wasm
+```
+
+Before shipping the plugin, verify that the expected exports are actually present in the compiled binary — for example with `wasm-objdump -x` (from the `wabt` package) or any equivalent WASM introspection tool: `memory`, `dcli_alloc`, `dcli_dealloc`, and the chosen business function must all appear in the export list.
+
+**A note on `dcli_last_error_message`.** `dynamic-cli` calls this export as a genuine multi-value WASM function, returning two `i32` results — equivalent to this WAT signature:
+
+```wat
+(func (export "dcli_last_error_message") (result i32 i32)
+    ;; push ptr, then len, in that order
+    ...)
+```
+
+Plain `extern "C"` functions in Rust compiled to `wasm32-unknown-unknown` cannot portably express a genuine two-`i32` multi-value WASM return across all toolchain versions — encoding schemes that pack both values into a single `i64` are **not** compatible with this contract; `dynamic-cli` calls the export expecting exactly two separate `i32` results, not one packed value. Verify your toolchain's actual generated code (for example by inspecting the compiled `.wasm` with `wasm-objdump` or `wasmtime`'s own introspection tools) before shipping a plugin that relies on this optional export. If your toolchain cannot express it reliably, omit the export — the error will simply surface with `message: None`, the documented, safe fallback.
+
+---
+
+## Conflict detection
+
+`CliBuilder::build()` merges the handlers of every static plugin, the mapped handlers of every WASM plugin, and every directly-registered handler into a single internal table, indexed by `implementation` name.
+
+If two sources claim the same name, `build()` returns an error identifying the offending plugin and name, with a suggestion to either rename the conflicting `implementation` in the YAML config, or remove the duplicate registration call.
+
+This applies uniformly regardless of which mechanism is used on each side. A static plugin colliding with a WASM plugin's mapped name is detected exactly like two static plugins colliding with each other.
+
+---
+
+## Restrictions and limitations (WASM plugins)
+
+This section distinguishes two categories of a different nature.
+
+A **restriction** is a deliberate structural choice, motivated by the security of the sandbox model. It will not change — lifting it would mean abandoning the isolation guarantee WASM plugins are meant to provide.
+
+A **limitation** is a missing feature in the current version, with no fundamental obstacle to adding it later. It might evolve someday, or might never be addressed if no concrete need arises — no commitment is made either way.
+
+### Restriction — no access to `ExecutionContext`
+
+WASM handlers do **not** receive the host application's `ExecutionContext`.
+
+This is a deliberate boundary, not an oversight. Trait objects cannot cross the WASM FFI boundary. Exposing arbitrary host state to a sandboxed guest would also defeat the very purpose of the sandbox.
+
+WASM plugins in this version therefore exchange only serialized arguments and a result code accompanied by an optional message — nothing else.
+
+Concretely: a WASM plugin cannot read or write the host application's in-memory state. It cannot access whatever the host's `ExecutionContext` wraps — a database connection, a session object, etc. It has no way to call back into host-defined behaviour.
+
+This restriction will not be lifted in a future version without calling the sandbox model itself into question.
+
+### Limitation — no host functions, no WASI
+
+This version exposes no host-defined function to the guest: no `host_log`, no `host_get_state`, nothing imported by the module beyond what WASM itself provides. It also does not wire up WASI.
+
+A WASM plugin is, in practice, a pure function from serialized arguments to a result code and an optional message. It cannot perform any I/O, any logging, or any interaction with the outside world through `dynamic-cli` itself.
+
+Unlike the previous restriction, this is not a security principle — it is simply something that has not been built yet. See the directions below.
+
+### Possible future directions for the limitations
+
+These are not commitments, and none is planned for the current cycle.
+
+**Restricted host functions** — exposing a small, explicit set of host-defined functions (for example `host_log`, `host_get_state`/`host_set_state`) that a guest could import. This would give controlled access to host capabilities without breaking the sandbox model.
+
+**Capability declarations** — a plugin declaring upfront which capabilities it needs (file access, network, shared state), with the host exposing only the corresponding host functions. This would preserve the sandbox model's security properties even as capabilities expand.
+
+**WASI integration** — via `wasmtime-wasi`, for plugins that genuinely need standardized, auditable access to the filesystem or the network.
+
+Each of these directions would constitute a new, explicitly versioned decision — not a silent extension of the current contract.
+
+---
+
+## Related references
+
+- Issue [#10](https://github.com/biface/dcli/issues/10) — the architectural
+  decision behind static (Option A) and WASM (Option C) plugins, and the
+  permanent exclusion of dynamic loading via `libloading` (Option B).
+- `src/plugin/mod.rs` (rustdoc) — the `Plugin` trait, full API reference.
+- `src/plugin/system.rs` (rustdoc) — `SystemPlugin`, a complete reference
+  implementation.
+- `src/plugin/wasm.rs` (rustdoc) — `WasmPlugin`, `WasmSerializationFormat`,
+  the Rust-side WASM loader API.
+- [`CONFIG_SYNTAX_REFERENCE.md`](CONFIG_SYNTAX_REFERENCE.md) — full YAML
+  command configuration syntax.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -50,6 +50,7 @@ use crate::error::{ConfigError, DynamicCliError, Result};
 use crate::executor::CommandHandler;
 use crate::help::{DefaultHelpFormatter, HelpFormatter};
 use crate::interface::{CliInterface, ReplInterface};
+use crate::plugin::Plugin;
 use crate::registry::CommandRegistry;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -109,6 +110,9 @@ pub struct CliBuilder {
 
     /// Custom help formatter. None = DefaultHelpFormatter used lazily.
     help_formatter: Option<Box<dyn HelpFormatter>>,
+
+    /// Registered plugins
+    plugins: Vec<Box<dyn Plugin>>,
 }
 
 impl CliBuilder {
@@ -129,6 +133,7 @@ impl CliBuilder {
             handlers: HashMap::new(),
             prompt: None,
             help_formatter: None,
+            plugins: Vec::new(),
         }
     }
 
@@ -251,6 +256,31 @@ impl CliBuilder {
         handler: Box<dyn CommandHandler>,
     ) -> Self {
         self.handlers.insert(name.into(), handler);
+        self
+    }
+
+    /// Register a plugin
+    ///
+    /// A plugin groups related handlers under a single unit. During `build()`,
+    /// each handler declared by the plugin is merged into the handler map.
+    /// Conflicts with already-registered handler names produce an error at
+    /// build time.
+    ///
+    /// The YAML config remains the sole source of truth for command definitions.
+    /// Plugin handlers are matched by their `implementation` name, exactly as
+    /// with [`register_handler`][Self::register_handler].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use dynamic_cli::CliBuilder;
+    /// use dynamic_cli::plugin::SystemPlugin;
+    ///
+    /// let builder = CliBuilder::new()
+    ///     .register_plugin(Box::new(SystemPlugin::new()));
+    /// ```
+    pub fn register_plugin(mut self, plugin: Box<dyn Plugin>) -> Self {
+        self.plugins.push(plugin);
         self
     }
 
@@ -386,6 +416,28 @@ impl CliBuilder {
 
         // Create registry and register commands
         let mut registry = CommandRegistry::new();
+
+        for plugin in self.plugins.drain(..) {
+            let plugin_name = plugin.name().to_string();
+            for (impl_name, handler) in plugin.handlers() {
+                if self.handlers.contains_key(&impl_name) {
+                    return Err(DynamicCliError::Config(ConfigError::InvalidSchema {
+                        reason: format!(
+                            "Plugin '{}' tried to register handler '{}' \
+                     which is already registered.",
+                            plugin_name, impl_name
+                        ),
+                        path: None,
+                        suggestion: Some(format!(
+                            "Remove the duplicate call to register_handler(\"{}\") \
+                     or rename the implementation in your YAML config.",
+                            impl_name
+                        )),
+                    }));
+                }
+                self.handlers.insert(impl_name, handler);
+            }
+        }
 
         for command_def in &config.commands {
             // Find handler for this command

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -105,14 +105,14 @@ pub struct CliBuilder {
     /// Registered command handlers (name -> handler)
     handlers: HashMap<String, Box<dyn CommandHandler>>,
 
+    /// Registered plugins, expanded into `handlers` during `build()`
+    plugins: Vec<Box<dyn Plugin>>,
+
     /// REPL prompt (if None, will use config default or "cli")
     prompt: Option<String>,
 
     /// Custom help formatter. None = DefaultHelpFormatter used lazily.
     help_formatter: Option<Box<dyn HelpFormatter>>,
-
-    /// Registered plugins
-    plugins: Vec<Box<dyn Plugin>>,
 }
 
 impl CliBuilder {
@@ -131,9 +131,9 @@ impl CliBuilder {
             config: None,
             context: None,
             handlers: HashMap::new(),
+            plugins: Vec::new(),
             prompt: None,
             help_formatter: None,
-            plugins: Vec::new(),
         }
     }
 
@@ -261,14 +261,16 @@ impl CliBuilder {
 
     /// Register a plugin
     ///
-    /// A plugin groups related handlers under a single unit. During `build()`,
-    /// each handler declared by the plugin is merged into the handler map.
-    /// Conflicts with already-registered handler names produce an error at
-    /// build time.
+    /// A plugin groups related handlers under a single unit. During
+    /// [`build()`][Self::build], each handler declared by the plugin is
+    /// merged into the handler map. Conflicts with already-registered
+    /// handler names (whether from another plugin or from
+    /// [`register_handler`][Self::register_handler]) produce a build-time
+    /// error.
     ///
-    /// The YAML config remains the sole source of truth for command definitions.
-    /// Plugin handlers are matched by their `implementation` name, exactly as
-    /// with [`register_handler`][Self::register_handler].
+    /// The YAML config remains the sole source of truth for command
+    /// definitions. Plugin handlers are matched by their `implementation`
+    /// name, exactly as with [`register_handler`][Self::register_handler].
     ///
     /// # Example
     ///
@@ -282,6 +284,57 @@ impl CliBuilder {
     pub fn register_plugin(mut self, plugin: Box<dyn Plugin>) -> Self {
         self.plugins.push(plugin);
         self
+    }
+
+    /// Load a WASM plugin from disk, map its business functions, and
+    /// register it
+    ///
+    /// Convenience wrapper around [`WasmPlugin::load`][crate::plugin::wasm::WasmPlugin::load],
+    /// [`WasmPlugin::with_function_map`][crate::plugin::wasm::WasmPlugin::with_function_map],
+    /// and [`register_plugin`][Self::register_plugin]. Only available with
+    /// the `wasm-plugins` feature.
+    ///
+    /// `function_map` is mandatory here, unlike the other `WasmPlugin`
+    /// builder methods (`with_format`, `with_metadata`), which have
+    /// reasonable defaults (YAML, file-name-derived metadata). A
+    /// `WasmPlugin` with an empty function map registers zero handlers —
+    /// silently inert — so this wrapper does not offer a path that skips
+    /// mapping. Applications that also need a non-default format or
+    /// explicit metadata should build the `WasmPlugin` directly and pass it
+    /// to [`register_plugin`][Self::register_plugin] instead.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the module cannot be loaded or fails mandatory
+    /// export validation. See `WASM_PLUGIN_INTERFACE.md` for the ABI
+    /// contract.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use dynamic_cli::CliBuilder;
+    /// use std::path::Path;
+    ///
+    /// # fn main() -> dynamic_cli::Result<()> {
+    /// let builder = CliBuilder::new()
+    ///     .register_wasm_plugin(
+    ///         Path::new("plugins/greet.wasm"),
+    ///         &[("greet_hello", "say_hello")],
+    ///     )?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "wasm-plugins")]
+    pub fn register_wasm_plugin(
+        self,
+        path: &std::path::Path,
+        function_map: &[(&str, &str)],
+    ) -> Result<Self> {
+        let mut plugin = crate::plugin::wasm::WasmPlugin::load(path)?;
+        for &(impl_name, wasm_fn_name) in function_map {
+            plugin = plugin.with_function_map(impl_name, wasm_fn_name);
+        }
+        Ok(self.register_plugin(Box::new(plugin)))
     }
 
     /// Set the REPL prompt
@@ -417,6 +470,10 @@ impl CliBuilder {
         // Create registry and register commands
         let mut registry = CommandRegistry::new();
 
+        // Expand plugins into the handler map before processing commands.
+        // Conflicts between plugins (or between a plugin and a directly
+        // registered handler) are detected here and produce a clear error,
+        // before any command resolution begins.
         for plugin in self.plugins.drain(..) {
             let plugin_name = plugin.name().to_string();
             for (impl_name, handler) in plugin.handlers() {
@@ -424,13 +481,13 @@ impl CliBuilder {
                     return Err(DynamicCliError::Config(ConfigError::InvalidSchema {
                         reason: format!(
                             "Plugin '{}' tried to register handler '{}' \
-                     which is already registered.",
+                             which is already registered.",
                             plugin_name, impl_name
                         ),
                         path: None,
                         suggestion: Some(format!(
                             "Remove the duplicate call to register_handler(\"{}\") \
-                     or rename the implementation in your YAML config.",
+                             or rename the implementation in your YAML config.",
                             impl_name
                         )),
                     }));

--- a/src/error/display.rs
+++ b/src/error/display.rs
@@ -26,6 +26,8 @@
 
 use colored::Colorize;
 
+#[cfg(feature = "wasm-plugins")]
+use crate::error::WasmError;
 use crate::error::{
     ConfigError, DynamicCliError, ExecutionError, ParseError, RegistryError, ValidationError,
 };
@@ -145,6 +147,8 @@ pub fn format_error(error: &DynamicCliError) -> String {
         DynamicCliError::Validation(e) => format_validation_error(&mut output, e),
         DynamicCliError::Execution(e) => format_execution_error(&mut output, e),
         DynamicCliError::Registry(e) => format_registry_error(&mut output, e),
+        #[cfg(feature = "wasm-plugins")]
+        DynamicCliError::Wasm(e) => format_wasm_error(&mut output, e),
         DynamicCliError::Io(e) => output.push_str(&format!("{}\n", e)),
     }
 
@@ -307,6 +311,27 @@ fn format_registry_error(output: &mut String, error: &RegistryError) {
         RegistryError::DuplicateRegistration { suggestion, .. } => suggestion.as_deref(),
         RegistryError::DuplicateAlias { suggestion, .. } => suggestion.as_deref(),
         RegistryError::MissingHandler { suggestion, .. } => suggestion.as_deref(),
+    };
+
+    append_suggestion(output, suggestion);
+}
+
+/// Format a WASM plugin error with its actionable suggestion
+///
+/// Only available when the `wasm-plugins` feature is enabled.
+///
+/// `GuestError` and `SerializationFailed` and `MemoryAccessFailed` carry no
+/// structured `suggestion` field — they surface only their `Display` message.
+#[cfg(feature = "wasm-plugins")]
+fn format_wasm_error(output: &mut String, error: &WasmError) {
+    output.push_str(&format!("{}\n", error));
+
+    let suggestion = match error {
+        WasmError::LoadFailed { suggestion, .. } => suggestion.as_deref(),
+        WasmError::FunctionNotFound { suggestion, .. } => suggestion.as_deref(),
+        WasmError::GuestError { .. } => None,
+        WasmError::SerializationFailed(_) => None,
+        WasmError::MemoryAccessFailed { .. } => None,
     };
 
     append_suggestion(output, suggestion);
@@ -663,6 +688,38 @@ mod tests {
         let formatted = format_error(&error);
         assert!(formatted.contains("run"));
         assert!(formatted.contains("Choose a different alias."));
+    }
+
+    // ── WasmError ────────────────────────────────────────────
+
+    #[cfg(feature = "wasm-plugins")]
+    #[test]
+    fn test_format_wasm_function_not_found_with_suggestion() {
+        let error: DynamicCliError = WasmError::FunctionNotFound {
+            function: "dcli_dealloc".to_string(),
+            module: "plugin.wasm".to_string(),
+            suggestion: Some("Export `dcli_dealloc(ptr: i32, size: i32)`.".to_string()),
+        }
+        .into();
+
+        let formatted = format_error(&error);
+        assert!(formatted.contains("dcli_dealloc"));
+        assert!(formatted.contains("Export `dcli_dealloc"));
+    }
+
+    #[cfg(feature = "wasm-plugins")]
+    #[test]
+    fn test_format_wasm_guest_error_without_suggestion_line() {
+        let error: DynamicCliError = WasmError::GuestError {
+            code: 1,
+            message: Some("invalid argument".to_string()),
+        }
+        .into();
+
+        let formatted = format_error(&error);
+        assert!(formatted.contains("invalid argument"));
+        // GuestError carries no structured suggestion — no "ℹ" line expected
+        assert!(!formatted.contains('ℹ'));
     }
 
     // ── display_error ────────────────────────────────────────

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -11,6 +11,7 @@
 //! - [`ValidationError`] : Validation errors
 //! - [`ExecutionError`] : Execution errors
 //! - [`RegistryError`] : Registry errors
+//! - [`WasmError`] : WASM plugin errors (feature = "wasm-plugins")
 //!
 //! ## Example
 //!

--- a/src/error/types.rs
+++ b/src/error/types.rs
@@ -36,6 +36,11 @@ pub enum DynamicCliError {
     #[error(transparent)]
     Registry(#[from] RegistryError),
 
+    /// WASM plugin errors (only available with the `wasm-plugins` feature)
+    #[cfg(feature = "wasm-plugins")]
+    #[error(transparent)]
+    Wasm(#[from] WasmError),
+
     /// I/O errors
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
@@ -672,6 +677,128 @@ pub enum RegistryError {
 }
 
 // ═══════════════════════════════════════════════════════════
+// WASM PLUGIN ERRORS (feature = "wasm-plugins")
+// ═══════════════════════════════════════════════════════════
+
+/// Errors related to loading and executing WASM plugins
+///
+/// Only available when the `wasm-plugins` feature is enabled.
+/// These errors occur when loading a `.wasm` module, validating its
+/// mandatory exports, or invoking a guest function across the host/guest
+/// boundary. See `WASM_PLUGIN_INTERFACE.md` for the full ABI contract.
+#[cfg(feature = "wasm-plugins")]
+#[derive(Debug, Error)]
+pub enum WasmError {
+    /// The `.wasm` module could not be loaded or instantiated
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use dynamic_cli::error::WasmError;
+    /// use std::path::PathBuf;
+    ///
+    /// let error = WasmError::LoadFailed {
+    ///     path: PathBuf::from("plugin.wasm"),
+    ///     source: anyhow::anyhow!("invalid magic number"),
+    ///     suggestion: Some("Verify the file is a valid WASM binary.".to_string()),
+    /// };
+    /// let msg = format!("{}", error);
+    /// assert!(msg.contains("plugin.wasm"));
+    /// ```
+    #[error("Failed to load WASM module: {path:?}: {source}")]
+    LoadFailed {
+        path: PathBuf,
+        #[source]
+        source: anyhow::Error,
+        /// Actionable hint surfaced to the user (not part of the Display string)
+        suggestion: Option<String>,
+    },
+
+    /// A mandatory or mapped export is missing from the module
+    ///
+    /// Mandatory exports are `memory`, `dcli_alloc`, `dcli_dealloc`, and the
+    /// mapped business function. See `WASM_PLUGIN_INTERFACE.md`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use dynamic_cli::error::WasmError;
+    ///
+    /// let error = WasmError::FunctionNotFound {
+    ///     function: "dcli_dealloc".to_string(),
+    ///     module: "plugin.wasm".to_string(),
+    ///     suggestion: Some(
+    ///         "Export `dcli_dealloc(ptr: i32, size: i32)` from the WASM module.".to_string()
+    ///     ),
+    /// };
+    /// let msg = format!("{}", error);
+    /// assert!(msg.contains("dcli_dealloc"));
+    /// ```
+    #[error("WASM function '{function}' not found in module '{module}'")]
+    FunctionNotFound {
+        function: String,
+        module: String,
+        /// Actionable hint surfaced to the user (not part of the Display string)
+        suggestion: Option<String>,
+    },
+
+    /// The guest function returned a non-zero error code
+    ///
+    /// `message` is populated from `dcli_last_error_message()` when the
+    /// module exports it; otherwise `None`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use dynamic_cli::error::WasmError;
+    ///
+    /// let error = WasmError::GuestError {
+    ///     code: 1,
+    ///     message: Some("invalid argument".to_string()),
+    /// };
+    /// let msg = format!("{}", error);
+    /// assert!(msg.contains('1'));
+    /// ```
+    #[error("WASM guest returned error code {code}{}",
+        .message.as_ref().map(|m| format!(": {m}")).unwrap_or_default())]
+    GuestError {
+        code: i32,
+        /// Detailed message from `dcli_last_error_message()`, if exported
+        message: Option<String>,
+    },
+
+    /// Failed to serialize handler arguments before crossing the WASM boundary
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use dynamic_cli::error::WasmError;
+    ///
+    /// let error = WasmError::SerializationFailed("unsupported map key type".to_string());
+    /// let msg = format!("{}", error);
+    /// assert!(msg.contains("unsupported map key type"));
+    /// ```
+    #[error("Failed to serialize arguments for WASM call: {0}")]
+    SerializationFailed(String),
+
+    /// Failed to read from or write to the guest's linear memory
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use dynamic_cli::error::WasmError;
+    ///
+    /// let error = WasmError::MemoryAccessFailed {
+    ///     reason: "write out of bounds".to_string(),
+    /// };
+    /// let msg = format!("{}", error);
+    /// assert!(msg.contains("out of bounds"));
+    /// ```
+    #[error("Failed to access WASM guest memory: {reason}")]
+    MemoryAccessFailed { reason: String },
+}
+
+// ═══════════════════════════════════════════════════════════
 // HELPERS FOR CREATING CONTEXTUAL ERRORS
 // ═══════════════════════════════════════════════════════════
 
@@ -932,6 +1059,69 @@ impl RegistryError {
             suggestion: Some(format!(
                 "Call .register_handler(\"{command}\", ...) before running."
             )),
+        }
+    }
+}
+
+#[cfg(feature = "wasm-plugins")]
+impl WasmError {
+    /// Create a `FunctionNotFound` error for a missing mandatory export
+    ///
+    /// The suggestion names the exact signature expected for the missing
+    /// export, taken from `WASM_PLUGIN_INTERFACE.md`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use dynamic_cli::error::WasmError;
+    ///
+    /// let error = WasmError::missing_mandatory_export("dcli_alloc", "plugin.wasm");
+    /// match error {
+    ///     WasmError::FunctionNotFound { suggestion, .. } => {
+    ///         assert!(suggestion.is_some());
+    ///     }
+    ///     _ => panic!("wrong variant"),
+    /// }
+    /// ```
+    pub fn missing_mandatory_export(function: &str, module: &str) -> Self {
+        let signature = match function {
+            "dcli_alloc" => "fn dcli_alloc(size: i32) -> i32",
+            "dcli_dealloc" => "fn dcli_dealloc(ptr: i32, size: i32)",
+            "memory" => "(memory (export \"memory\") ...)",
+            other => other,
+        };
+        Self::FunctionNotFound {
+            function: function.to_string(),
+            module: module.to_string(),
+            suggestion: Some(format!(
+                "Export `{signature}` from the WASM module. \
+                 See WASM_PLUGIN_INTERFACE.md for the full contract."
+            )),
+        }
+    }
+
+    /// Create a `GuestError` from a raw error code, without a detailed message
+    ///
+    /// Used when the module does not export `dcli_last_error_message`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use dynamic_cli::error::WasmError;
+    ///
+    /// let error = WasmError::guest_error_without_message(2);
+    /// match error {
+    ///     WasmError::GuestError { code, message } => {
+    ///         assert_eq!(code, 2);
+    ///         assert!(message.is_none());
+    ///     }
+    ///     _ => panic!("wrong variant"),
+    /// }
+    /// ```
+    pub fn guest_error_without_message(code: i32) -> Self {
+        Self::GuestError {
+            code,
+            message: None,
         }
     }
 }
@@ -1257,5 +1447,105 @@ mod tests {
         let msg = format!("{}", error);
         assert!(msg.contains("run"));
         assert!(!msg.contains("Choose")); // suggestion separate from Display
+    }
+
+    // ── WasmError ────────────────────────────────────────────
+
+    #[cfg(feature = "wasm-plugins")]
+    #[test]
+    fn test_wasm_load_failed_display() {
+        let error = WasmError::LoadFailed {
+            path: PathBuf::from("plugin.wasm"),
+            source: anyhow::anyhow!("invalid magic number"),
+            suggestion: None,
+        };
+        let msg = format!("{}", error);
+        assert!(msg.contains("plugin.wasm"));
+        assert!(msg.contains("invalid magic number"));
+    }
+
+    #[cfg(feature = "wasm-plugins")]
+    #[test]
+    fn test_wasm_function_not_found_display() {
+        let error = WasmError::FunctionNotFound {
+            function: "dcli_alloc".to_string(),
+            module: "plugin.wasm".to_string(),
+            suggestion: None,
+        };
+        let msg = format!("{}", error);
+        assert!(msg.contains("dcli_alloc"));
+        assert!(msg.contains("plugin.wasm"));
+    }
+
+    #[cfg(feature = "wasm-plugins")]
+    #[test]
+    fn test_wasm_missing_mandatory_export_helper_has_suggestion() {
+        let error = WasmError::missing_mandatory_export("dcli_dealloc", "plugin.wasm");
+        match error {
+            WasmError::FunctionNotFound {
+                suggestion,
+                function,
+                ..
+            } => {
+                assert_eq!(function, "dcli_dealloc");
+                let s = suggestion.unwrap();
+                assert!(s.contains("dcli_dealloc"));
+                assert!(s.contains("WASM_PLUGIN_INTERFACE.md"));
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[cfg(feature = "wasm-plugins")]
+    #[test]
+    fn test_wasm_guest_error_with_message_display() {
+        let error = WasmError::GuestError {
+            code: 1,
+            message: Some("invalid argument".to_string()),
+        };
+        let msg = format!("{}", error);
+        assert!(msg.contains('1'));
+        assert!(msg.contains("invalid argument"));
+    }
+
+    #[cfg(feature = "wasm-plugins")]
+    #[test]
+    fn test_wasm_guest_error_without_message_display() {
+        let error = WasmError::guest_error_without_message(2);
+        let msg = format!("{}", error);
+        assert!(msg.contains('2'));
+        match error {
+            WasmError::GuestError { message, .. } => assert!(message.is_none()),
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[cfg(feature = "wasm-plugins")]
+    #[test]
+    fn test_wasm_serialization_failed_display() {
+        let error = WasmError::SerializationFailed("unsupported map key type".to_string());
+        let msg = format!("{}", error);
+        assert!(msg.contains("unsupported map key type"));
+    }
+
+    #[cfg(feature = "wasm-plugins")]
+    #[test]
+    fn test_wasm_memory_access_failed_display() {
+        let error = WasmError::MemoryAccessFailed {
+            reason: "write out of bounds".to_string(),
+        };
+        let msg = format!("{}", error);
+        assert!(msg.contains("out of bounds"));
+    }
+
+    #[cfg(feature = "wasm-plugins")]
+    #[test]
+    fn test_wasm_error_converts_into_dynamic_cli_error() {
+        let wasm_err = WasmError::guest_error_without_message(1);
+        let err: DynamicCliError = wasm_err.into();
+        match err {
+            DynamicCliError::Wasm(WasmError::GuestError { code, .. }) => assert_eq!(code, 1),
+            _ => panic!("wrong variant"),
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,7 @@ pub mod executor;
 pub mod help;
 pub mod interface;
 pub mod parser;
+pub mod plugin;
 pub mod registry;
 pub mod utils;
 pub mod validator;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,11 @@ pub use builder::{CliApp, CliBuilder};
 // Helper system
 pub use help::{DefaultHelpFormatter, HelpFormatter};
 
+// Plugin system
+#[cfg(feature = "wasm-plugins")]
+pub use plugin::wasm::{WasmPlugin, WasmSerializationFormat};
+pub use plugin::{Plugin, SystemPlugin};
+
 // Utility functions
 pub use utils::{
     detect_type, format_bytes, format_duration, get_extension, has_extension, is_blank, normalize,
@@ -196,6 +201,11 @@ pub mod prelude {
 
     // Help system — re-exported so framework users need only `use dynamic_cli::prelude::*`
     pub use crate::help::{DefaultHelpFormatter, HelpFormatter};
+
+    // Plugin system
+    #[cfg(feature = "wasm-plugins")]
+    pub use crate::plugin::wasm::{WasmPlugin, WasmSerializationFormat};
+    pub use crate::plugin::{Plugin, SystemPlugin};
 
     // Utilities (most commonly used)
     pub use crate::utils::{detect_type, is_blank, normalize, parse_bool, parse_float, parse_int};

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -1,0 +1,368 @@
+//! Plugin system for `dynamic-cli`
+//!
+//! This module defines the [`Plugin`] trait, the standard extension mechanism
+//! for `dynamic-cli` applications. A plugin groups related command handlers
+//! under a single unit of deployment with explicit metadata.
+//!
+//! # Design
+//!
+//! The plugin system follows the principle established by DD-001 and DD-002:
+//! - **The YAML config is the sole source of truth** for command definitions.
+//! - **Plugins supply handlers only** — identified by their `implementation`
+//!   name, exactly as [`CliBuilder::register_handler`] does.
+//! - **The framework controls registration** — the plugin declares what it
+//!   provides via [`Plugin::handlers`]; the framework validates and registers.
+//!   The plugin never receives a `&mut CommandRegistry`.
+//!
+//! # Standard plugin
+//!
+//! [`SystemPlugin`] is provided out of the box. It supplies handlers for the
+//! common system commands (`help`, `version`, `exit` / `quit`) that every
+//! application typically needs. Users declare the corresponding commands in
+//! their YAML config and register the plugin with a single call.
+//!
+//! # Example
+//!
+//! ```
+//! use dynamic_cli::plugin::{Plugin, SystemPlugin};
+//! use dynamic_cli::executor::CommandHandler;
+//! use std::collections::HashMap;
+//!
+//! // A minimal plugin supplying one handler
+//! struct GreetPlugin;
+//!
+//! impl Plugin for GreetPlugin {
+//!     fn name(&self) -> &str { "greet" }
+//!     fn version(&self) -> &str { "0.1.0" }
+//!     fn description(&self) -> &str { "Greeting commands" }
+//!
+//!     fn handlers(&self) -> Vec<(String, Box<dyn CommandHandler>)> {
+//!         struct HelloHandler;
+//!         impl CommandHandler for HelloHandler {
+//!             fn execute(
+//!                 &self,
+//!                 _ctx: &mut dyn dynamic_cli::context::ExecutionContext,
+//!                 args: &HashMap<String, String>,
+//!             ) -> dynamic_cli::Result<()> {
+//!                 let default = "World".to_string();
+//!                 println!("Hello, {}!", args.get("name").unwrap_or(&default));
+//!                 Ok(())
+//!             }
+//!         }
+//!         vec![("greet_hello".to_string(), Box::new(HelloHandler))]
+//!     }
+//! }
+//!
+//! // Verify the trait contract
+//! let plugin = GreetPlugin;
+//! assert_eq!(plugin.name(), "greet");
+//! let handlers = plugin.handlers();
+//! assert_eq!(handlers.len(), 1);
+//! assert_eq!(handlers[0].0, "greet_hello");
+//! ```
+
+use crate::executor::CommandHandler;
+
+// Sub-modules
+pub mod system;
+
+// Sub-module for the WASM loader (feature-gated, added in #23)
+#[cfg(feature = "wasm-plugins")]
+pub mod wasm;
+
+// Re-exports for convenience
+pub use system::SystemPlugin;
+
+// ============================================================================
+// Plugin trait
+// ============================================================================
+
+/// Extension point for grouping related command handlers.
+///
+/// A plugin declares its metadata and the handlers it provides. The framework
+/// validates and registers those handlers into the [`CommandRegistry`] during
+/// [`CliBuilder::build()`]. The plugin never has direct access to the registry.
+///
+/// # Contract
+///
+/// - [`Plugin::handlers`] returns `(implementation_name, handler)` pairs.
+/// - Each `implementation_name` must match the `implementation` field of a
+///   command declared in the YAML config — exactly as with
+///   [`CliBuilder::register_handler`].
+/// - The YAML config remains the sole source of truth for command definitions.
+///   A plugin cannot inject commands that are not declared in the config.
+///
+/// # Object safety
+///
+/// This trait is intentionally object-safe (`dyn Plugin` is valid).
+/// Do not add methods with generic type parameters.
+///
+/// # Thread safety
+///
+/// Implementations must be `Send + Sync`.
+///
+/// # Example
+///
+/// ```
+/// use dynamic_cli::plugin::{Plugin, SystemPlugin};
+/// use dynamic_cli::executor::CommandHandler;
+/// use dynamic_cli::context::ExecutionContext;
+/// use std::collections::HashMap;
+///
+/// struct MyPlugin;
+///
+/// impl Plugin for MyPlugin {
+///     fn name(&self) -> &str { "my-plugin" }
+///     fn version(&self) -> &str { "1.0.0" }
+///     fn description(&self) -> &str { "My custom plugin" }
+///
+///     fn handlers(&self) -> Vec<(String, Box<dyn CommandHandler>)> {
+///         struct MyHandler;
+///         impl CommandHandler for MyHandler {
+///             fn execute(
+///                 &self,
+///                 _ctx: &mut dyn ExecutionContext,
+///                 _args: &HashMap<String, String>,
+///             ) -> dynamic_cli::Result<()> {
+///                 println!("executed");
+///                 Ok(())
+///             }
+///         }
+///         vec![("my_handler".to_string(), Box::new(MyHandler))]
+///     }
+/// }
+///
+/// // Trait object usage (object-safe)
+/// let plugin: Box<dyn Plugin> = Box::new(MyPlugin);
+/// assert_eq!(plugin.name(), "my-plugin");
+/// assert_eq!(plugin.version(), "1.0.0");
+/// assert_eq!(plugin.handlers().len(), 1);
+/// ```
+pub trait Plugin: Send + Sync {
+    /// Short identifier for this plugin (e.g. `"system"`, `"greet"`).
+    fn name(&self) -> &str;
+
+    /// Semantic version string (e.g. `"1.0.0"`).
+    fn version(&self) -> &str;
+
+    /// Human-readable description of what this plugin provides.
+    fn description(&self) -> &str;
+
+    /// Returns the handlers this plugin contributes.
+    ///
+    /// Each element is `(implementation_name, handler)` where
+    /// `implementation_name` matches the `implementation` field in the YAML
+    /// config for the corresponding command.
+    fn handlers(&self) -> Vec<(String, Box<dyn CommandHandler>)>;
+}
+
+// ============================================================================
+// Tests — Plugin trait contract and fixture plugins
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::ExecutionContext;
+    use crate::Result;
+    use std::any::Any;
+    use std::collections::HashMap;
+
+    // -------------------------------------------------------------------------
+    // Test fixtures (trait-level — no SystemPlugin dependency here)
+    // -------------------------------------------------------------------------
+
+    #[derive(Default)]
+    struct TestContext;
+
+    impl ExecutionContext for TestContext {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+        fn as_any_mut(&mut self) -> &mut dyn Any {
+            self
+        }
+    }
+
+    struct EchoPlugin;
+
+    impl Plugin for EchoPlugin {
+        fn name(&self) -> &str {
+            "echo"
+        }
+        fn version(&self) -> &str {
+            "0.1.0"
+        }
+        fn description(&self) -> &str {
+            "Echoes its arguments"
+        }
+
+        fn handlers(&self) -> Vec<(String, Box<dyn CommandHandler>)> {
+            struct EchoHandler;
+            impl CommandHandler for EchoHandler {
+                fn execute(
+                    &self,
+                    _ctx: &mut dyn ExecutionContext,
+                    args: &HashMap<String, String>,
+                ) -> Result<()> {
+                    for (k, v) in args {
+                        println!("{k}={v}");
+                    }
+                    Ok(())
+                }
+            }
+            vec![("echo_handler".to_string(), Box::new(EchoHandler))]
+        }
+    }
+
+    struct MultiHandlerPlugin;
+
+    impl Plugin for MultiHandlerPlugin {
+        fn name(&self) -> &str {
+            "multi"
+        }
+        fn version(&self) -> &str {
+            "1.0.0"
+        }
+        fn description(&self) -> &str {
+            "Plugin with multiple handlers"
+        }
+
+        fn handlers(&self) -> Vec<(String, Box<dyn CommandHandler>)> {
+            struct NoopHandler;
+            impl CommandHandler for NoopHandler {
+                fn execute(
+                    &self,
+                    _: &mut dyn ExecutionContext,
+                    _: &HashMap<String, String>,
+                ) -> Result<()> {
+                    Ok(())
+                }
+            }
+            vec![
+                ("multi_alpha".to_string(), Box::new(NoopHandler)),
+                ("multi_beta".to_string(), Box::new(NoopHandler)),
+                ("multi_gamma".to_string(), Box::new(NoopHandler)),
+            ]
+        }
+    }
+
+    struct MetadataPlugin;
+
+    impl Plugin for MetadataPlugin {
+        fn name(&self) -> &str {
+            "acme-analytics"
+        }
+        fn version(&self) -> &str {
+            "3.1.4"
+        }
+        fn description(&self) -> &str {
+            "Analytics commands for Acme Corp"
+        }
+        fn handlers(&self) -> Vec<(String, Box<dyn CommandHandler>)> {
+            vec![]
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Plugin trait — object safety
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_plugin_is_object_safe() {
+        // If this compiles, Plugin is dyn-compatible.
+        let _: Box<dyn Plugin> = Box::new(EchoPlugin);
+    }
+
+    #[test]
+    fn test_plugin_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<EchoPlugin>();
+        assert_send_sync::<MultiHandlerPlugin>();
+        assert_send_sync::<SystemPlugin>();
+    }
+
+    // -------------------------------------------------------------------------
+    // EchoPlugin — minimal single-handler plugin
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_echo_plugin_metadata() {
+        let p = EchoPlugin;
+        assert_eq!(p.name(), "echo");
+        assert_eq!(p.version(), "0.1.0");
+        assert_eq!(p.description(), "Echoes its arguments");
+    }
+
+    #[test]
+    fn test_echo_plugin_handlers_count() {
+        let handlers = EchoPlugin.handlers();
+        assert_eq!(handlers.len(), 1);
+        assert_eq!(handlers[0].0, "echo_handler");
+    }
+
+    #[test]
+    fn test_echo_handler_executes() {
+        let handlers = EchoPlugin.handlers();
+        let (_, handler) = &handlers[0];
+        let mut ctx = TestContext;
+        let mut args = HashMap::new();
+        args.insert("key".to_string(), "value".to_string());
+        assert!(handler.execute(&mut ctx, &args).is_ok());
+    }
+
+    // -------------------------------------------------------------------------
+    // MultiHandlerPlugin
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_multi_handler_plugin_count() {
+        let handlers = MultiHandlerPlugin.handlers();
+        assert_eq!(handlers.len(), 3);
+        let names: Vec<&str> = handlers.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(names.contains(&"multi_alpha"));
+        assert!(names.contains(&"multi_beta"));
+        assert!(names.contains(&"multi_gamma"));
+    }
+
+    // -------------------------------------------------------------------------
+    // MetadataPlugin
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_metadata_plugin_fields() {
+        let p = MetadataPlugin;
+        assert_eq!(p.name(), "acme-analytics");
+        assert_eq!(p.version(), "3.1.4");
+        assert_eq!(p.description(), "Analytics commands for Acme Corp");
+        assert_eq!(p.handlers().len(), 0);
+    }
+
+    // -------------------------------------------------------------------------
+    // Plugin as trait object — collections
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_plugin_trait_object_in_vec() {
+        let plugins: Vec<Box<dyn Plugin>> = vec![
+            Box::new(EchoPlugin),
+            Box::new(MultiHandlerPlugin),
+            Box::new(MetadataPlugin),
+            Box::new(SystemPlugin::new()),
+        ];
+        assert_eq!(plugins.len(), 4);
+        let names: Vec<&str> = plugins.iter().map(|p| p.name()).collect();
+        assert!(names.contains(&"echo"));
+        assert!(names.contains(&"multi"));
+        assert!(names.contains(&"acme-analytics"));
+        assert!(names.contains(&"system"));
+    }
+
+    #[test]
+    fn test_plugin_handlers_total_count() {
+        let plugins: Vec<Box<dyn Plugin>> =
+            vec![Box::new(EchoPlugin), Box::new(MultiHandlerPlugin)];
+        let total: usize = plugins.iter().map(|p| p.handlers().len()).sum();
+        assert_eq!(total, 4); // 1 + 3
+    }
+}

--- a/src/plugin/system.rs
+++ b/src/plugin/system.rs
@@ -1,0 +1,507 @@
+//! Built-in system plugin for `dynamic-cli`
+//!
+//! Provides [`SystemPlugin`], a ready-made plugin supplying the three handlers
+//! that every `dynamic-cli` application typically needs: `system_help`,
+//! `system_version`, and `system_exit`.
+//!
+//! See [`SystemPlugin`] for usage and YAML configuration examples.
+
+use crate::config::schema::CommandsConfig;
+use crate::context::ExecutionContext;
+use crate::executor::CommandHandler;
+use crate::help::{DefaultHelpFormatter, HelpFormatter};
+use crate::plugin::Plugin;
+use crate::Result;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+// ============================================================================
+// SystemPlugin
+// ============================================================================
+
+/// Built-in plugin providing standard system commands.
+///
+/// Supplies ready-made handlers for the commands that every `dynamic-cli`
+/// application typically needs. Users declare the corresponding commands in
+/// their YAML config and register the plugin once — no manual handler wiring.
+///
+/// # Provided handlers
+///
+/// | Implementation name | Behaviour |
+/// |---------------------|-----------|
+/// | `system_help`       | Prints application or per-command help via the active [`HelpFormatter`][crate::help::HelpFormatter] |
+/// | `system_version`    | Prints the version from `metadata.version` in the config |
+/// | `system_exit`       | Runs the shutdown callback then exits (default: `std::process::exit(0)`) |
+///
+/// # Shutdown callback
+///
+/// `system_exit` accepts an optional callback via [`SystemPlugin::with_exit_fn`].
+/// The callback runs **before** the process exits, allowing the application to
+/// flush buffers, close connections, save state, or log a goodbye message.
+///
+/// The default callback calls `std::process::exit(0)` directly. Provide a
+/// custom one when a clean shutdown sequence is required:
+///
+/// ```no_run
+/// use dynamic_cli::plugin::SystemPlugin;
+///
+/// let plugin = SystemPlugin::new()
+///     .with_exit_fn(|| {
+///         // flush logs, close DB connections, save session…
+///         eprintln!("Goodbye.");
+///         std::process::exit(0);
+///     });
+/// ```
+///
+/// # YAML config
+///
+/// Declare the commands you want to activate:
+///
+/// ```yaml
+/// commands:
+///   - name: help
+///     implementation: system_help
+///     description: "Show help"
+///     aliases: ["h", "?"]
+///     required: false
+///     arguments: []
+///     options: []
+///
+///   - name: version
+///     implementation: system_version
+///     description: "Show version"
+///     required: false
+///     arguments: []
+///     options: []
+///
+///   - name: exit
+///     implementation: system_exit
+///     description: "Exit the application"
+///     aliases: ["quit", "q"]
+///     required: false
+///     arguments: []
+///     options: []
+/// ```
+///
+/// # Example
+///
+/// ```
+/// use dynamic_cli::plugin::{Plugin, SystemPlugin};
+///
+/// let plugin = SystemPlugin::new();
+/// assert_eq!(plugin.name(), "system");
+///
+/// let handlers = plugin.handlers();
+/// let names: Vec<&str> = handlers.iter().map(|(n, _)| n.as_str()).collect();
+/// assert!(names.contains(&"system_help"));
+/// assert!(names.contains(&"system_version"));
+/// assert!(names.contains(&"system_exit"));
+/// ```
+pub struct SystemPlugin {
+    /// Application config, needed by `system_help` and `system_version`.
+    config: Option<CommandsConfig>,
+
+    /// Shutdown callback invoked by `system_exit`.
+    ///
+    /// Defaults to `|| std::process::exit(0)`.
+    /// Override with [`SystemPlugin::with_exit_fn`] for a clean shutdown
+    /// sequence (flush buffers, close connections, save state, etc.).
+    exit_fn: Arc<dyn Fn() + Send + Sync>,
+}
+
+impl SystemPlugin {
+    /// Create a new `SystemPlugin` with the default shutdown behaviour.
+    ///
+    /// The default exit callback calls `std::process::exit(0)`. Use
+    /// [`with_exit_fn`][Self::with_exit_fn] to supply a custom shutdown
+    /// sequence.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use dynamic_cli::plugin::{Plugin, SystemPlugin};
+    ///
+    /// let plugin = SystemPlugin::new();
+    /// assert_eq!(plugin.name(), "system");
+    /// ```
+    pub fn new() -> Self {
+        Self {
+            config: None,
+            exit_fn: Arc::new(|| std::process::exit(0)),
+        }
+    }
+
+    /// Attach a config so the system handlers can access app metadata.
+    ///
+    /// Called automatically by [`CliBuilder::build()`] when the plugin is
+    /// registered via [`CliBuilder::register_plugin`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use dynamic_cli::plugin::{Plugin, SystemPlugin};
+    /// use dynamic_cli::config::schema::{CommandsConfig, Metadata};
+    ///
+    /// let config = CommandsConfig {
+    ///     metadata: Metadata {
+    ///         version: "1.0.0".to_string(),
+    ///         prompt: "myapp".to_string(),
+    ///         prompt_suffix: " > ".to_string(),
+    ///     },
+    ///     commands: vec![],
+    ///     global_options: vec![],
+    /// };
+    ///
+    /// let plugin = SystemPlugin::new().with_config(config);
+    /// assert_eq!(plugin.name(), "system");
+    /// ```
+    pub fn with_config(mut self, config: CommandsConfig) -> Self {
+        self.config = Some(config);
+        self
+    }
+
+    /// Supply a custom shutdown callback for `system_exit`.
+    ///
+    /// The callback is invoked when the user runs the command bound to
+    /// `system_exit`. Use it to flush buffers, close connections, persist
+    /// state, or display a goodbye message before the process terminates.
+    ///
+    /// The callback must be `Fn() + Send + Sync + 'static`.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use dynamic_cli::plugin::SystemPlugin;
+    ///
+    /// let plugin = SystemPlugin::new()
+    ///     .with_exit_fn(|| {
+    ///         eprintln!("Saving session…");
+    ///         // close resources here
+    ///         std::process::exit(0);
+    ///     });
+    /// ```
+    pub fn with_exit_fn<F>(mut self, f: F) -> Self
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
+        self.exit_fn = Arc::new(f);
+        self
+    }
+}
+
+impl Default for SystemPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Plugin for SystemPlugin {
+    fn name(&self) -> &str {
+        "system"
+    }
+
+    fn version(&self) -> &str {
+        env!("CARGO_PKG_VERSION")
+    }
+
+    fn description(&self) -> &str {
+        "Built-in system commands: help, version, exit"
+    }
+
+    fn handlers(&self) -> Vec<(String, Box<dyn CommandHandler>)> {
+        let config = self.config.clone();
+        let exit_fn = self.exit_fn.clone();
+
+        vec![
+            (
+                "system_help".to_string(),
+                Box::new(SystemHelpHandler {
+                    config: config.clone(),
+                }),
+            ),
+            (
+                "system_version".to_string(),
+                Box::new(SystemVersionHandler { config }),
+            ),
+            (
+                "system_exit".to_string(),
+                Box::new(SystemExitHandler { exit_fn }),
+            ),
+        ]
+    }
+}
+
+// ============================================================================
+// System handlers (private)
+// ============================================================================
+
+/// Handler for `system_help` — prints app-level or per-command help.
+struct SystemHelpHandler {
+    config: Option<CommandsConfig>,
+}
+
+impl CommandHandler for SystemHelpHandler {
+    fn execute(
+        &self,
+        _ctx: &mut dyn ExecutionContext,
+        args: &HashMap<String, String>,
+    ) -> Result<()> {
+        let formatter = DefaultHelpFormatter::new();
+
+        match self.config.as_ref() {
+            Some(cfg) => {
+                if let Some(command) = args.get("command") {
+                    print!("{}", formatter.format_command(cfg, command));
+                } else {
+                    print!("{}", formatter.format_app(cfg));
+                }
+            }
+            None => {
+                println!("Help is not available (no configuration loaded).");
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Handler for `system_version` — prints the app version from config metadata.
+struct SystemVersionHandler {
+    config: Option<CommandsConfig>,
+}
+
+impl CommandHandler for SystemVersionHandler {
+    fn execute(
+        &self,
+        _ctx: &mut dyn ExecutionContext,
+        _args: &HashMap<String, String>,
+    ) -> Result<()> {
+        match self.config.as_ref() {
+            Some(cfg) => println!("{}", cfg.metadata.version),
+            None => println!("(version unknown)"),
+        }
+        Ok(())
+    }
+}
+
+/// Handler for `system_exit` — invokes the shutdown callback and exits.
+///
+/// The callback is set via [`SystemPlugin::with_exit_fn`]. The default
+/// callback calls `std::process::exit(0)`.
+struct SystemExitHandler {
+    /// Shutdown callback — runs before the process exits.
+    exit_fn: Arc<dyn Fn() + Send + Sync>,
+}
+
+impl CommandHandler for SystemExitHandler {
+    fn execute(
+        &self,
+        _ctx: &mut dyn ExecutionContext,
+        _args: &HashMap<String, String>,
+    ) -> Result<()> {
+        // Run the shutdown sequence supplied by the application.
+        // The default implementation calls std::process::exit(0).
+        (self.exit_fn)();
+        // Unreachable in production (exit_fn terminates the process),
+        // but required for the return type in test configurations
+        // where exit_fn does not call std::process::exit.
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::schema::{CommandsConfig, Metadata};
+    use std::any::Any;
+
+    // -------------------------------------------------------------------------
+    // Test fixtures
+    // -------------------------------------------------------------------------
+
+    #[derive(Default)]
+    struct TestContext;
+
+    impl ExecutionContext for TestContext {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+        fn as_any_mut(&mut self) -> &mut dyn Any {
+            self
+        }
+    }
+
+    fn test_config() -> CommandsConfig {
+        CommandsConfig {
+            metadata: Metadata {
+                version: "2.0.0".to_string(),
+                prompt: "testapp".to_string(),
+                prompt_suffix: " > ".to_string(),
+            },
+            commands: vec![],
+            global_options: vec![],
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Metadata
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_system_plugin_metadata() {
+        let p = SystemPlugin::new();
+        assert_eq!(p.name(), "system");
+        assert!(!p.version().is_empty());
+        assert!(!p.description().is_empty());
+    }
+
+    #[test]
+    fn test_system_plugin_default() {
+        let p = SystemPlugin::default();
+        assert_eq!(p.name(), "system");
+    }
+
+    #[test]
+    fn test_system_plugin_handler_names() {
+        let handlers = SystemPlugin::new().handlers();
+        let names: Vec<&str> = handlers.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(names.contains(&"system_help"));
+        assert!(names.contains(&"system_version"));
+        assert!(names.contains(&"system_exit"));
+        assert_eq!(handlers.len(), 3);
+    }
+
+    // -------------------------------------------------------------------------
+    // with_config
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_system_plugin_with_config() {
+        let plugin = SystemPlugin::new().with_config(test_config());
+        assert!(plugin.config.is_some());
+        assert_eq!(plugin.config.unwrap().metadata.version, "2.0.0");
+    }
+
+    #[test]
+    fn test_system_version_handler_with_config() {
+        let plugin = SystemPlugin::new().with_config(test_config());
+        let handlers = plugin.handlers();
+        let (name, handler) = handlers
+            .iter()
+            .find(|(n, _)| n == "system_version")
+            .unwrap();
+        assert_eq!(name, "system_version");
+        let mut ctx = TestContext;
+        assert!(handler.execute(&mut ctx, &HashMap::new()).is_ok());
+    }
+
+    #[test]
+    fn test_system_version_handler_without_config() {
+        let handlers = SystemPlugin::new().handlers();
+        let (_, handler) = handlers
+            .iter()
+            .find(|(n, _)| n == "system_version")
+            .unwrap();
+        let mut ctx = TestContext;
+        assert!(handler.execute(&mut ctx, &HashMap::new()).is_ok());
+    }
+
+    #[test]
+    fn test_system_help_handler_with_config() {
+        let plugin = SystemPlugin::new().with_config(test_config());
+        let handlers = plugin.handlers();
+        let (_, handler) = handlers.iter().find(|(n, _)| n == "system_help").unwrap();
+        let mut ctx = TestContext;
+        assert!(handler.execute(&mut ctx, &HashMap::new()).is_ok());
+    }
+
+    #[test]
+    fn test_system_help_handler_with_command_arg() {
+        let plugin = SystemPlugin::new().with_config(test_config());
+        let handlers = plugin.handlers();
+        let (_, handler) = handlers.iter().find(|(n, _)| n == "system_help").unwrap();
+        let mut ctx = TestContext;
+        let mut args = HashMap::new();
+        args.insert("command".to_string(), "nonexistent".to_string());
+        assert!(handler.execute(&mut ctx, &args).is_ok());
+    }
+
+    #[test]
+    fn test_system_help_handler_without_config() {
+        let handlers = SystemPlugin::new().handlers();
+        let (_, handler) = handlers.iter().find(|(n, _)| n == "system_help").unwrap();
+        let mut ctx = TestContext;
+        assert!(handler.execute(&mut ctx, &HashMap::new()).is_ok());
+    }
+
+    // -------------------------------------------------------------------------
+    // Shutdown callback
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_system_exit_default_callback_is_set() {
+        // Verify that SystemPlugin::new() initialises exit_fn without panicking.
+        // The default callback (process::exit) cannot be invoked in tests;
+        // we only check that the plugin builds and exposes the handler.
+        let plugin = SystemPlugin::new();
+        let handlers = plugin.handlers();
+        assert!(handlers.iter().any(|(n, _)| n == "system_exit"));
+    }
+
+    #[test]
+    fn test_system_exit_custom_callback_invoked() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let called = Arc::new(AtomicBool::new(false));
+        let called_clone = called.clone();
+
+        let plugin = SystemPlugin::new().with_exit_fn(move || {
+            called_clone.store(true, Ordering::SeqCst);
+            // Does NOT call std::process::exit — safe in tests.
+        });
+
+        let handlers = plugin.handlers();
+        let (_, handler) = handlers.iter().find(|(n, _)| n == "system_exit").unwrap();
+
+        let mut ctx = TestContext;
+        let result = handler.execute(&mut ctx, &HashMap::new());
+
+        assert!(result.is_ok());
+        assert!(
+            called.load(Ordering::SeqCst),
+            "shutdown callback was not invoked"
+        );
+    }
+
+    #[test]
+    fn test_system_exit_callback_ignores_args() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let called = Arc::new(AtomicBool::new(false));
+        let called_clone = called.clone();
+
+        let plugin = SystemPlugin::new().with_exit_fn(move || {
+            called_clone.store(true, Ordering::SeqCst);
+        });
+
+        let handlers = plugin.handlers();
+        let (_, handler) = handlers.iter().find(|(n, _)| n == "system_exit").unwrap();
+
+        let mut ctx = TestContext;
+        let mut args = HashMap::new();
+        args.insert("unexpected_arg".to_string(), "value".to_string());
+
+        assert!(handler.execute(&mut ctx, &args).is_ok());
+        assert!(called.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_with_exit_fn_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>(_: T) {}
+        let plugin = SystemPlugin::new().with_exit_fn(|| {});
+        assert_send_sync(plugin);
+    }
+}

--- a/src/plugin/wasm.rs
+++ b/src/plugin/wasm.rs
@@ -1,14 +1,763 @@
-//! WASM plugin loader for `dynamic-cli`
+//! WASM plugin loader for `dynamic-cli` (Option C — DD-021)
 //!
-//! This module is gated behind the `wasm-plugins` feature flag and will be
-//! implemented in issue #23.
+//! Provides [`WasmPlugin`], a [`Plugin`] implementation backed by a sandboxed
+//! WebAssembly module loaded and executed via `wasmtime`. Only available
+//! when the `wasm-plugins` feature is enabled.
 //!
-//! Enable with:
-//! ```toml
-//! [dependencies]
-//! dynamic-cli = { version = "0.4.0", features = ["wasm-plugins"] }
+//! # Why WASM plugins
+//!
+//! Static plugins ([`SystemPlugin`][crate::plugin::SystemPlugin] and Option A
+//! in general) must be compiled into the host binary. WASM plugins trade
+//! that compile-time coupling for a safe, cross-platform sandbox: a `.wasm`
+//! module can be distributed independently of the host application and
+//! loaded at runtime, with no `unsafe` code on the host side.
+//!
+//! # ABI contract — mandatory exports
+//!
+//! Every WASM module loaded as a [`WasmPlugin`] **must** export:
+//!
+//! | Export | Signature | Purpose |
+//! |--------|-----------|---------|
+//! | `memory` | (standard linear memory) | Shared buffer for argument/result transfer |
+//! | `dcli_alloc` | `(size: i32) -> i32` | Host asks the guest to reserve `size` bytes; returns the pointer |
+//! | `dcli_dealloc` | `(ptr: i32, size: i32)` | Host asks the guest to free a buffer it previously allocated |
+//! | *(business function)* | `(ptr: i32, len: i32) -> i32` | Reads serialized args at `ptr`/`len`; returns `0` on success, non-zero on error |
+//!
+//! The business function's exported name is chosen freely by the plugin
+//! author and mapped to an `implementation` name via
+//! [`WasmPlugin::with_function_map`].
+//!
+//! # ABI contract — optional exports
+//!
+//! | Export | Signature | Purpose |
+//! |--------|-----------|---------|
+//! | `dcli_last_error_message` | `() -> (ptr: i32, len: i32)` | Detailed error message when the business function returns non-zero |
+//!
+//! When absent, errors surface with the raw code only
+//! ([`WasmError::guest_error_without_message`]).
+//!
+//! # Serialization
+//!
+//! Handler arguments (`HashMap<String, String>`) are serialized to a byte
+//! buffer before crossing the host/guest boundary. YAML is the default,
+//! consistent with the framework's config-first principle (DD-002); JSON is
+//! available via [`WasmPlugin::with_format`].
+//!
+//! # Known limitation — no `ExecutionContext` access
+//!
+//! WASM handlers do **not** receive the host's [`ExecutionContext`]. Trait
+//! objects cannot cross the WASM FFI boundary, and exposing arbitrary host
+//! state to a sandboxed guest would defeat the purpose of the sandbox. WASM
+//! plugins in this version only exchange serialized arguments and a result
+//! code/message.
+//!
+//! Future work may introduce a restricted set of host functions (e.g.
+//! `host_log`, `host_get_state`) or WASI integration for guests that need
+//! controlled access to host capabilities — see DD-021 for the open
+//! discussion. This version intentionally ships without them.
+//!
+//! Full reference: `WASM_PLUGIN_INTERFACE.md`.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use dynamic_cli::plugin::wasm::{WasmPlugin, WasmSerializationFormat};
+//! use std::path::Path;
+//!
+//! # fn main() -> dynamic_cli::Result<()> {
+//! let plugin = WasmPlugin::load(Path::new("plugins/greet.wasm"))?
+//!     .with_function_map("greet_hello", "say_hello")
+//!     .with_format(WasmSerializationFormat::Yaml)
+//!     .with_metadata("greet", "1.0.0", "Greeting commands");
+//! # Ok(())
+//! # }
 //! ```
-//!
-//! # Status
-//!
-//! Not yet implemented — tracked in [#23](https://github.com/biface/dcli/issues/23).
+
+use crate::context::ExecutionContext;
+use crate::error::WasmError;
+use crate::executor::CommandHandler;
+use crate::plugin::Plugin;
+use crate::Result;
+use std::collections::HashMap;
+use std::path::Path;
+use wasmtime::{Engine, Instance, Module, Store};
+
+// ============================================================================
+// WasmSerializationFormat
+// ============================================================================
+
+/// Serialization format used to exchange handler arguments across the
+/// host/guest boundary.
+///
+/// YAML is the default, consistent with the framework's config-first
+/// principle (DD-002). Guests that prefer JSON can request it via
+/// [`WasmPlugin::with_format`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum WasmSerializationFormat {
+    /// YAML-encoded arguments (default)
+    #[default]
+    Yaml,
+    /// JSON-encoded arguments
+    Json,
+}
+
+impl WasmSerializationFormat {
+    /// Serialize a handler argument map into bytes using this format.
+    fn serialize(self, args: &HashMap<String, String>) -> Result<Vec<u8>> {
+        let bytes = match self {
+            Self::Yaml => serde_yaml::to_string(args)
+                .map_err(|e| WasmError::SerializationFailed(e.to_string()))?
+                .into_bytes(),
+            Self::Json => serde_json::to_vec(args)
+                .map_err(|e| WasmError::SerializationFailed(e.to_string()))?,
+        };
+        Ok(bytes)
+    }
+}
+
+// ============================================================================
+// Mandatory export names
+// ============================================================================
+
+const EXPORT_MEMORY: &str = "memory";
+const EXPORT_ALLOC: &str = "dcli_alloc";
+const EXPORT_DEALLOC: &str = "dcli_dealloc";
+const EXPORT_LAST_ERROR: &str = "dcli_last_error_message";
+
+// ============================================================================
+// WasmPlugin
+// ============================================================================
+
+/// A [`Plugin`] backed by a sandboxed WASM module.
+///
+/// Load a `.wasm` (or `.wat`, useful for testing) module with [`WasmPlugin::load`],
+/// map its business functions to `implementation` names with
+/// [`with_function_map`][Self::with_function_map], then register it via
+/// [`CliBuilder::register_plugin`][crate::CliBuilder::register_plugin] or the
+/// convenience [`CliBuilder::register_wasm_plugin`][crate::CliBuilder::register_wasm_plugin].
+///
+/// See the [module-level documentation](self) for the full ABI contract.
+pub struct WasmPlugin {
+    name: String,
+    version: String,
+    description: String,
+    engine: Engine,
+    module: Module,
+    /// `implementation_name -> wasm_exported_function_name`
+    function_map: HashMap<String, String>,
+    format: WasmSerializationFormat,
+}
+
+impl WasmPlugin {
+    /// Load a WASM module from disk and validate its mandatory exports.
+    ///
+    /// Accepts both binary `.wasm` and text `.wat` modules (the latter is
+    /// primarily useful for tests and minimal fixtures).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WasmError::LoadFailed`] if the file cannot be read or fails
+    /// to compile/validate. Returns [`WasmError::FunctionNotFound`] if
+    /// `memory`, `dcli_alloc`, or `dcli_dealloc` is missing — these three
+    /// are mandatory regardless of which business functions are mapped
+    /// later.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use dynamic_cli::plugin::wasm::WasmPlugin;
+    /// use std::path::Path;
+    ///
+    /// # fn main() -> dynamic_cli::Result<()> {
+    /// let plugin = WasmPlugin::load(Path::new("plugins/greet.wasm"))?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn load(path: &Path) -> Result<Self> {
+        let bytes = std::fs::read(path).map_err(|e| WasmError::LoadFailed {
+            path: path.to_path_buf(),
+            source: anyhow::Error::new(e),
+            suggestion: Some("Verify the path is correct and the file is readable.".to_string()),
+        })?;
+
+        Self::from_bytes(&bytes, path)
+    }
+
+    /// Load a WASM module from raw bytes (binary `.wasm` or text `.wat`).
+    ///
+    /// Used internally by [`load`][Self::load]. Exposed for tests and for
+    /// embedding scenarios where the module bytes are not stored on disk
+    /// (e.g. fetched over the network).
+    ///
+    /// Validates the same mandatory exports as [`load`][Self::load].
+    pub fn from_bytes(bytes: &[u8], origin: &Path) -> Result<Self> {
+        let engine = Engine::default();
+
+        let module = Module::new(&engine, bytes).map_err(|e| WasmError::LoadFailed {
+            path: origin.to_path_buf(),
+            source: e.into(),
+            suggestion: Some("Verify the file is a valid WASM binary or WAT module.".to_string()),
+        })?;
+
+        let module_label = origin.display().to_string();
+        Self::validate_mandatory_exports(&module, &module_label)?;
+
+        let default_name = origin
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("wasm-plugin")
+            .to_string();
+
+        Ok(Self {
+            name: default_name,
+            version: "0.0.0".to_string(),
+            description: "WASM plugin (no metadata provided)".to_string(),
+            engine,
+            module,
+            function_map: HashMap::new(),
+            format: WasmSerializationFormat::default(),
+        })
+    }
+
+    /// Verify that `memory`, `dcli_alloc`, and `dcli_dealloc` are exported.
+    ///
+    /// These three exports are mandatory for every WASM plugin regardless
+    /// of which business functions are mapped — without them the host has
+    /// no safe way to exchange data with the guest or to free guest memory
+    /// after a call.
+    fn validate_mandatory_exports(module: &Module, module_label: &str) -> Result<()> {
+        let exported_names: Vec<&str> = module.exports().map(|e| e.name()).collect();
+
+        for required in [EXPORT_MEMORY, EXPORT_ALLOC, EXPORT_DEALLOC] {
+            if !exported_names.contains(&required) {
+                return Err(WasmError::missing_mandatory_export(required, module_label).into());
+            }
+        }
+        Ok(())
+    }
+
+    /// Map an `implementation` name to a WASM-exported business function.
+    ///
+    /// The exported function name is chosen freely by the plugin author —
+    /// `dynamic-cli` imposes no naming convention beyond the four reserved
+    /// names (`memory`, `dcli_alloc`, `dcli_dealloc`, `dcli_last_error_message`).
+    ///
+    /// Existence of `wasm_fn_name` in the module is verified at handler
+    /// construction time, in [`Plugin::handlers`].
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use dynamic_cli::plugin::wasm::WasmPlugin;
+    /// use std::path::Path;
+    ///
+    /// # fn main() -> dynamic_cli::Result<()> {
+    /// let plugin = WasmPlugin::load(Path::new("plugins/greet.wasm"))?
+    ///     .with_function_map("greet_hello", "say_hello");
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn with_function_map(mut self, impl_name: &str, wasm_fn_name: &str) -> Self {
+        self.function_map
+            .insert(impl_name.to_string(), wasm_fn_name.to_string());
+        self
+    }
+
+    /// Set the serialization format used for argument exchange.
+    ///
+    /// Defaults to [`WasmSerializationFormat::Yaml`].
+    pub fn with_format(mut self, format: WasmSerializationFormat) -> Self {
+        self.format = format;
+        self
+    }
+
+    /// Set plugin metadata (name, version, description).
+    ///
+    /// When not called, defaults are derived from the module's file name
+    /// (`name`), `"0.0.0"` (`version`), and a generic description.
+    pub fn with_metadata(mut self, name: &str, version: &str, description: &str) -> Self {
+        self.name = name.to_string();
+        self.version = version.to_string();
+        self.description = description.to_string();
+        self
+    }
+}
+
+impl Plugin for WasmPlugin {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn version(&self) -> &str {
+        &self.version
+    }
+
+    fn description(&self) -> &str {
+        &self.description
+    }
+
+    fn handlers(&self) -> Vec<(String, Box<dyn CommandHandler>)> {
+        self.function_map
+            .iter()
+            .map(|(impl_name, wasm_fn_name)| {
+                let handler: Box<dyn CommandHandler> = Box::new(WasmHandler {
+                    engine: self.engine.clone(),
+                    module: self.module.clone(),
+                    module_label: self.name.clone(),
+                    wasm_fn_name: wasm_fn_name.clone(),
+                    format: self.format,
+                });
+                (impl_name.clone(), handler)
+            })
+            .collect()
+    }
+}
+
+// ============================================================================
+// WasmHandler (private)
+// ============================================================================
+
+/// [`CommandHandler`] that invokes a single exported WASM business function.
+///
+/// One instance is created per mapped `implementation` name in
+/// [`WasmPlugin::handlers`]. Each call to [`execute`][CommandHandler::execute]
+/// creates a fresh `Store` and `Instance` — WASM instantiation is cheap and
+/// this keeps each invocation isolated, with no state leaking between calls.
+struct WasmHandler {
+    engine: Engine,
+    module: Module,
+    /// Plugin name, used only to identify the module in error messages
+    module_label: String,
+    wasm_fn_name: String,
+    format: WasmSerializationFormat,
+}
+
+impl WasmHandler {
+    /// Run the full call sequence: alloc → write → call → dealloc → result.
+    ///
+    /// `dcli_dealloc` is invoked on every exit path — including when the
+    /// business function itself returns a non-zero error code — so the
+    /// guest never accumulates unfreed buffers across repeated calls.
+    fn call_guest(&self, args: &HashMap<String, String>) -> Result<()> {
+        let mut store = Store::new(&self.engine, ());
+        let instance =
+            Instance::new(&mut store, &self.module, &[]).map_err(|e| WasmError::LoadFailed {
+                path: std::path::PathBuf::from(&self.module_label),
+                source: e.into(),
+                suggestion: Some("Failed to instantiate the WASM module.".to_string()),
+            })?;
+
+        let memory = instance
+            .get_memory(&mut store, EXPORT_MEMORY)
+            .ok_or_else(|| {
+                WasmError::missing_mandatory_export(EXPORT_MEMORY, &self.module_label)
+            })?;
+
+        let alloc = instance
+            .get_typed_func::<i32, i32>(&mut store, EXPORT_ALLOC)
+            .map_err(|_| WasmError::missing_mandatory_export(EXPORT_ALLOC, &self.module_label))?;
+
+        let dealloc = instance
+            .get_typed_func::<(i32, i32), ()>(&mut store, EXPORT_DEALLOC)
+            .map_err(|_| WasmError::missing_mandatory_export(EXPORT_DEALLOC, &self.module_label))?;
+
+        let business_fn = instance
+            .get_typed_func::<(i32, i32), i32>(&mut store, self.wasm_fn_name.as_str())
+            .map_err(|_| WasmError::FunctionNotFound {
+                function: self.wasm_fn_name.clone(),
+                module: self.module_label.clone(),
+                suggestion: Some(format!(
+                    "Export `fn {}(ptr: i32, len: i32) -> i32` from the WASM module, \
+                     or check the name passed to `with_function_map`.",
+                    self.wasm_fn_name
+                )),
+            })?;
+
+        // Serialize arguments and request guest-owned buffer space.
+        let payload = self.format.serialize(args)?;
+        let len = payload.len() as i32;
+
+        let ptr = alloc
+            .call(&mut store, len)
+            .map_err(|e| WasmError::MemoryAccessFailed {
+                reason: e.to_string(),
+            })?;
+
+        memory
+            .write(&mut store, ptr as usize, &payload)
+            .map_err(|e| WasmError::MemoryAccessFailed {
+                reason: e.to_string(),
+            })?;
+
+        // Invoke the business function. Regardless of outcome, the guest
+        // buffer is freed before this function returns (see below).
+        let call_result = business_fn.call(&mut store, (ptr, len));
+
+        // Always free the buffer we allocated, on every exit path.
+        let dealloc_result = dealloc.call(&mut store, (ptr, len));
+
+        let code = call_result.map_err(|e| WasmError::MemoryAccessFailed {
+            reason: format!("business function trapped: {e}"),
+        })?;
+
+        // A failure to deallocate is logged via the returned error only if
+        // the business call itself succeeded — otherwise the guest error
+        // takes priority as the more actionable failure.
+        if code == 0 {
+            dealloc_result.map_err(|e| WasmError::MemoryAccessFailed {
+                reason: format!("dcli_dealloc failed: {e}"),
+            })?;
+            return Ok(());
+        }
+
+        // Non-zero return code: attempt to retrieve a detailed message via
+        // the optional `dcli_last_error_message` export.
+        //
+        // dealloc_result is intentionally not surfaced here even if it
+        // failed: the guest's own error code is the more actionable signal
+        // for the caller, and a secondary dealloc failure on an already
+        // failing call would only obscure it.
+        let message = self.read_last_error_message(&mut store, &instance);
+        Err(WasmError::GuestError { code, message }.into())
+    }
+
+    /// Best-effort retrieval of a detailed error message from the guest.
+    ///
+    /// Returns `None` when the module does not export
+    /// `dcli_last_error_message`, or when reading the message fails for any
+    /// reason. A missing or unreadable message degrades to the raw error
+    /// code — it never escalates into a separate error of its own.
+    fn read_last_error_message(
+        &self,
+        store: &mut Store<()>,
+        instance: &Instance,
+    ) -> Option<String> {
+        let last_error_fn = instance
+            .get_typed_func::<(), (i32, i32)>(&mut *store, EXPORT_LAST_ERROR)
+            .ok()?;
+        let (ptr, len) = last_error_fn.call(&mut *store, ()).ok()?;
+        if len <= 0 {
+            return None;
+        }
+        let memory = instance.get_memory(&mut *store, EXPORT_MEMORY)?;
+        let mut buf = vec![0u8; len as usize];
+        memory.read(&mut *store, ptr as usize, &mut buf).ok()?;
+        String::from_utf8(buf).ok()
+    }
+}
+
+impl CommandHandler for WasmHandler {
+    fn execute(
+        &self,
+        _ctx: &mut dyn ExecutionContext,
+        args: &HashMap<String, String>,
+    ) -> Result<()> {
+        // ExecutionContext is intentionally not forwarded to the guest —
+        // see the module-level "Known limitation" section.
+        self.call_guest(args)
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::any::Any;
+    use std::path::PathBuf;
+
+    #[derive(Default)]
+    struct TestContext;
+
+    impl ExecutionContext for TestContext {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+        fn as_any_mut(&mut self) -> &mut dyn Any {
+            self
+        }
+    }
+
+    /// A minimal valid module: memory + dcli_alloc + dcli_dealloc + a
+    /// business function `ok_handler` that always returns 0 (success).
+    ///
+    /// Allocation/deallocation are no-ops here (a fixed bump pointer at
+    /// offset 1024) — sufficient for ABI-contract tests, not a realistic
+    /// allocator.
+    const WAT_MINIMAL_OK: &str = r#"
+        (module
+            (memory (export "memory") 1)
+            (func (export "dcli_alloc") (param i32) (result i32)
+                i32.const 1024)
+            (func (export "dcli_dealloc") (param i32 i32))
+            (func (export "ok_handler") (param i32 i32) (result i32)
+                i32.const 0)
+        )
+    "#;
+
+    /// Same as above, but the business function always returns error code 1,
+    /// with no `dcli_last_error_message` export.
+    const WAT_MINIMAL_ERROR: &str = r#"
+        (module
+            (memory (export "memory") 1)
+            (func (export "dcli_alloc") (param i32) (result i32)
+                i32.const 1024)
+            (func (export "dcli_dealloc") (param i32 i32))
+            (func (export "err_handler") (param i32 i32) (result i32)
+                i32.const 1)
+        )
+    "#;
+
+    /// Same as the error module, but also exports `dcli_last_error_message`
+    /// pointing at a fixed "boom" string baked into a data segment.
+    const WAT_WITH_ERROR_MESSAGE: &str = r#"
+        (module
+            (memory (export "memory") 1)
+            (data (i32.const 2048) "boom")
+            (func (export "dcli_alloc") (param i32) (result i32)
+                i32.const 1024)
+            (func (export "dcli_dealloc") (param i32 i32))
+            (func (export "err_handler") (param i32 i32) (result i32)
+                i32.const 1)
+            (func (export "dcli_last_error_message") (result i32 i32)
+                i32.const 2048
+                i32.const 4)
+        )
+    "#;
+
+    /// Missing `dcli_dealloc` entirely.
+    const WAT_MISSING_DEALLOC: &str = r#"
+        (module
+            (memory (export "memory") 1)
+            (func (export "dcli_alloc") (param i32) (result i32)
+                i32.const 1024)
+            (func (export "ok_handler") (param i32 i32) (result i32)
+                i32.const 0)
+        )
+    "#;
+
+    /// Missing `memory` entirely.
+    const WAT_MISSING_MEMORY: &str = r#"
+        (module
+            (func (export "dcli_alloc") (param i32) (result i32)
+                i32.const 1024)
+            (func (export "dcli_dealloc") (param i32 i32))
+            (func (export "ok_handler") (param i32 i32) (result i32)
+                i32.const 0)
+        )
+    "#;
+
+    fn load_wat(wat: &str) -> Result<WasmPlugin> {
+        WasmPlugin::from_bytes(wat.as_bytes(), &PathBuf::from("test.wat"))
+    }
+
+    // -------------------------------------------------------------------------
+    // Loading & mandatory export validation
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_load_minimal_valid_module_succeeds() {
+        let plugin = load_wat(WAT_MINIMAL_OK);
+        assert!(plugin.is_ok());
+    }
+
+    #[test]
+    fn test_load_missing_dealloc_fails() {
+        let result = load_wat(WAT_MISSING_DEALLOC);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_load_missing_memory_fails() {
+        let result = load_wat(WAT_MISSING_MEMORY);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_load_invalid_bytes_fails() {
+        let result = WasmPlugin::from_bytes(b"not a wasm module", &PathBuf::from("bad.wasm"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_default_metadata_derived_from_filename() {
+        let plugin = WasmPlugin::from_bytes(
+            WAT_MINIMAL_OK.as_bytes(),
+            &PathBuf::from("plugins/greet.wat"),
+        )
+        .unwrap();
+        assert_eq!(plugin.name(), "greet");
+    }
+
+    // -------------------------------------------------------------------------
+    // Metadata builder methods
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_with_metadata_overrides_defaults() {
+        let plugin =
+            load_wat(WAT_MINIMAL_OK)
+                .unwrap()
+                .with_metadata("custom", "2.5.0", "A custom plugin");
+        assert_eq!(plugin.name(), "custom");
+        assert_eq!(plugin.version(), "2.5.0");
+        assert_eq!(plugin.description(), "A custom plugin");
+    }
+
+    #[test]
+    fn test_with_format_defaults_to_yaml() {
+        let plugin = load_wat(WAT_MINIMAL_OK).unwrap();
+        assert_eq!(plugin.format, WasmSerializationFormat::Yaml);
+    }
+
+    #[test]
+    fn test_with_format_can_be_set_to_json() {
+        let plugin = load_wat(WAT_MINIMAL_OK)
+            .unwrap()
+            .with_format(WasmSerializationFormat::Json);
+        assert_eq!(plugin.format, WasmSerializationFormat::Json);
+    }
+
+    // -------------------------------------------------------------------------
+    // Plugin::handlers()
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_handlers_reflects_function_map() {
+        let plugin = load_wat(WAT_MINIMAL_OK)
+            .unwrap()
+            .with_function_map("my_command", "ok_handler");
+        let handlers = plugin.handlers();
+        assert_eq!(handlers.len(), 1);
+        assert_eq!(handlers[0].0, "my_command");
+    }
+
+    #[test]
+    fn test_handlers_empty_without_function_map() {
+        let plugin = load_wat(WAT_MINIMAL_OK).unwrap();
+        assert_eq!(plugin.handlers().len(), 0);
+    }
+
+    // -------------------------------------------------------------------------
+    // Execution — success path
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_execute_success_returns_ok() {
+        let plugin = load_wat(WAT_MINIMAL_OK)
+            .unwrap()
+            .with_function_map("cmd", "ok_handler");
+        let handlers = plugin.handlers();
+        let (_, handler) = &handlers[0];
+
+        let mut ctx = TestContext;
+        let args = HashMap::new();
+        assert!(handler.execute(&mut ctx, &args).is_ok());
+    }
+
+    #[test]
+    fn test_execute_with_args_serializes_without_error() {
+        let plugin = load_wat(WAT_MINIMAL_OK)
+            .unwrap()
+            .with_function_map("cmd", "ok_handler");
+        let handlers = plugin.handlers();
+        let (_, handler) = &handlers[0];
+
+        let mut ctx = TestContext;
+        let mut args = HashMap::new();
+        args.insert("name".to_string(), "World".to_string());
+        args.insert("count".to_string(), "3".to_string());
+        assert!(handler.execute(&mut ctx, &args).is_ok());
+    }
+
+    #[test]
+    fn test_execute_repeated_calls_do_not_exhaust_guest() {
+        // Verifies that dcli_dealloc being called on every exit path allows
+        // the same handler to be invoked many times without issue — a
+        // regression test for the "always deallocate" requirement.
+        let plugin = load_wat(WAT_MINIMAL_OK)
+            .unwrap()
+            .with_function_map("cmd", "ok_handler");
+        let handlers = plugin.handlers();
+        let (_, handler) = &handlers[0];
+
+        let mut ctx = TestContext;
+        for _ in 0..50 {
+            let args = HashMap::new();
+            assert!(handler.execute(&mut ctx, &args).is_ok());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Execution — error path
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_execute_guest_error_without_message() {
+        let plugin = load_wat(WAT_MINIMAL_ERROR)
+            .unwrap()
+            .with_function_map("cmd", "err_handler");
+        let handlers = plugin.handlers();
+        let (_, handler) = &handlers[0];
+
+        let mut ctx = TestContext;
+        let args = HashMap::new();
+        let result = handler.execute(&mut ctx, &args);
+        assert!(result.is_err());
+
+        match result.unwrap_err() {
+            crate::error::DynamicCliError::Wasm(WasmError::GuestError { code, message }) => {
+                assert_eq!(code, 1);
+                assert!(message.is_none());
+            }
+            other => panic!("unexpected error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_execute_guest_error_with_message() {
+        let plugin = load_wat(WAT_WITH_ERROR_MESSAGE)
+            .unwrap()
+            .with_function_map("cmd", "err_handler");
+        let handlers = plugin.handlers();
+        let (_, handler) = &handlers[0];
+
+        let mut ctx = TestContext;
+        let args = HashMap::new();
+        let result = handler.execute(&mut ctx, &args);
+        assert!(result.is_err());
+
+        match result.unwrap_err() {
+            crate::error::DynamicCliError::Wasm(WasmError::GuestError { code, message }) => {
+                assert_eq!(code, 1);
+                assert_eq!(message, Some("boom".to_string()));
+            }
+            other => panic!("unexpected error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_execute_unmapped_function_name_fails() {
+        let plugin = load_wat(WAT_MINIMAL_OK)
+            .unwrap()
+            .with_function_map("cmd", "does_not_exist");
+        let handlers = plugin.handlers();
+        let (_, handler) = &handlers[0];
+
+        let mut ctx = TestContext;
+        let args = HashMap::new();
+        assert!(handler.execute(&mut ctx, &args).is_err());
+    }
+
+    // -------------------------------------------------------------------------
+    // Thread safety
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_wasm_plugin_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<WasmPlugin>();
+    }
+}

--- a/src/plugin/wasm.rs
+++ b/src/plugin/wasm.rs
@@ -1,0 +1,14 @@
+//! WASM plugin loader for `dynamic-cli`
+//!
+//! This module is gated behind the `wasm-plugins` feature flag and will be
+//! implemented in issue #23.
+//!
+//! Enable with:
+//! ```toml
+//! [dependencies]
+//! dynamic-cli = { version = "0.4.0", features = ["wasm-plugins"] }
+//! ```
+//!
+//! # Status
+//!
+//! Not yet implemented — tracked in [#23](https://github.com/biface/dcli/issues/23).

--- a/tests/integration/system_plugin_test.rs
+++ b/tests/integration/system_plugin_test.rs
@@ -1,0 +1,245 @@
+//! Integration test — SystemPlugin (Option A, DD-021)
+//!
+//! Exercises the full chain `CliBuilder -> build() -> CliApp -> run_cli()`
+//! with [`SystemPlugin`] registered alongside a directly-registered handler,
+//! using only the crate's public API — exactly as a downstream application
+//! would.
+//!
+//! Unit tests in `src/plugin/system.rs` already cover each `SystemPlugin`
+//! handler in isolation. This file instead verifies that the plugin
+//! integrates correctly through the builder: conflict-free registration,
+//! correct dispatch via the YAML-declared `implementation` name, and
+//! coexistence with a user-registered handler in the same application.
+
+use dynamic_cli::config::schema::{CommandDefinition, Metadata};
+use dynamic_cli::plugin::SystemPlugin;
+use dynamic_cli::prelude::*;
+use std::any::Any;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+// ============================================================================
+// Test fixtures
+// ============================================================================
+
+/// Execution context that records invocations of the user-defined handler.
+///
+/// Shared via `Arc<Mutex<_>>` so the test can inspect side effects after
+/// `run_cli()` returns (handlers only receive `&mut dyn ExecutionContext`,
+/// not an owned, inspectable value).
+#[derive(Default)]
+struct RecordingContext {
+    greeted: Arc<Mutex<Vec<String>>>,
+}
+
+impl ExecutionContext for RecordingContext {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+/// A user-defined handler, registered alongside `SystemPlugin`, to verify
+/// the two registration paths (`register_handler` and `register_plugin`)
+/// coexist without interference.
+struct GreetHandler {
+    greeted: Arc<Mutex<Vec<String>>>,
+}
+
+impl CommandHandler for GreetHandler {
+    fn execute(
+        &self,
+        _ctx: &mut dyn ExecutionContext,
+        args: &HashMap<String, String>,
+    ) -> dynamic_cli::Result<()> {
+        let name = args
+            .get("name")
+            .cloned()
+            .unwrap_or_else(|| "World".to_string());
+        self.greeted.lock().unwrap().push(name);
+        Ok(())
+    }
+}
+
+/// Builds a minimal config declaring the three `SystemPlugin` commands plus
+/// one user command (`greet`) bound to `GreetHandler`.
+fn test_config() -> CommandsConfig {
+    CommandsConfig {
+        metadata: Metadata {
+            version: "1.2.3".to_string(),
+            prompt: "testapp".to_string(),
+            prompt_suffix: " > ".to_string(),
+        },
+        commands: vec![
+            CommandDefinition {
+                name: "version".to_string(),
+                aliases: vec![],
+                description: "Show version".to_string(),
+                required: false,
+                arguments: vec![],
+                options: vec![],
+                implementation: "system_version".to_string(),
+            },
+            CommandDefinition {
+                name: "help".to_string(),
+                aliases: vec!["h".to_string()],
+                description: "Show help".to_string(),
+                required: false,
+                arguments: vec![],
+                options: vec![],
+                implementation: "system_help".to_string(),
+            },
+            CommandDefinition {
+                name: "exit".to_string(),
+                aliases: vec!["quit".to_string()],
+                description: "Exit the application".to_string(),
+                required: false,
+                arguments: vec![],
+                options: vec![],
+                implementation: "system_exit".to_string(),
+            },
+            CommandDefinition {
+                name: "greet".to_string(),
+                aliases: vec![],
+                description: "Greet someone".to_string(),
+                required: true,
+                arguments: vec![],
+                options: vec![],
+                implementation: "greet_handler".to_string(),
+            },
+        ],
+        global_options: vec![],
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+/// `SystemPlugin` handlers are reachable through the full builder chain,
+/// dispatched by their YAML-declared `implementation` name.
+#[test]
+fn system_plugin_version_command_executes_via_full_chain() {
+    let app = CliBuilder::new()
+        .config(test_config())
+        .context(Box::new(RecordingContext::default()))
+        .register_plugin(Box::new(SystemPlugin::new()))
+        .register_handler(
+            "greet_handler",
+            Box::new(GreetHandler {
+                greeted: Arc::new(Mutex::new(Vec::new())),
+            }),
+        )
+        .build()
+        .expect("build should succeed with SystemPlugin registered");
+
+    let result = app.run_cli(vec!["version".to_string()]);
+    assert!(
+        result.is_ok(),
+        "system_version handler should execute without error"
+    );
+}
+
+/// `system_help` executes without error when invoked through the registry
+/// (as opposed to the `--help` interception path tested elsewhere).
+#[test]
+fn system_plugin_help_command_executes_via_full_chain() {
+    let app = CliBuilder::new()
+        .config(test_config())
+        .context(Box::new(RecordingContext::default()))
+        .register_plugin(Box::new(SystemPlugin::new()))
+        .register_handler(
+            "greet_handler",
+            Box::new(GreetHandler {
+                greeted: Arc::new(Mutex::new(Vec::new())),
+            }),
+        )
+        .build()
+        .expect("build should succeed");
+
+    let result = app.run_cli(vec!["help".to_string()]);
+    assert!(
+        result.is_ok(),
+        "system_help handler should execute without error"
+    );
+}
+
+/// `SystemPlugin`'s handlers and a directly-registered user handler coexist
+/// in the same registry without interfering with each other.
+#[test]
+fn system_plugin_coexists_with_user_registered_handler() {
+    let greeted = Arc::new(Mutex::new(Vec::new()));
+
+    let app = CliBuilder::new()
+        .config(test_config())
+        .context(Box::new(RecordingContext::default()))
+        .register_plugin(Box::new(SystemPlugin::new()))
+        .register_handler(
+            "greet_handler",
+            Box::new(GreetHandler {
+                greeted: greeted.clone(),
+            }),
+        )
+        .build()
+        .expect("build should succeed");
+
+    let result = app.run_cli(vec!["greet".to_string()]);
+    assert!(
+        result.is_ok(),
+        "user-registered greet_handler should execute"
+    );
+    assert_eq!(
+        greeted.lock().unwrap().as_slice(),
+        &["World".to_string()],
+        "user handler should have recorded its invocation"
+    );
+}
+
+/// `SystemPlugin` aliases declared in the YAML config (`h` for `help`,
+/// `quit` for `exit`) resolve correctly through the registry built by
+/// `CliBuilder`.
+#[test]
+fn system_plugin_alias_resolves_to_same_handler() {
+    let app = CliBuilder::new()
+        .config(test_config())
+        .context(Box::new(RecordingContext::default()))
+        .register_plugin(Box::new(SystemPlugin::new()))
+        .register_handler(
+            "greet_handler",
+            Box::new(GreetHandler {
+                greeted: Arc::new(Mutex::new(Vec::new())),
+            }),
+        )
+        .build()
+        .expect("build should succeed");
+
+    let result = app.run_cli(vec!["h".to_string()]);
+    assert!(result.is_ok(), "alias 'h' should resolve to system_help");
+}
+
+/// Registering `SystemPlugin` twice (or alongside a direct handler with the
+/// same `implementation` name) produces a build-time error rather than
+/// silently overwriting a handler — the conflict-detection path exercised
+/// at unit level in `builder.rs` also holds through the public API.
+#[test]
+fn duplicate_plugin_registration_fails_at_build() {
+    let result = CliBuilder::new()
+        .config(test_config())
+        .context(Box::new(RecordingContext::default()))
+        .register_plugin(Box::new(SystemPlugin::new()))
+        .register_plugin(Box::new(SystemPlugin::new()))
+        .register_handler(
+            "greet_handler",
+            Box::new(GreetHandler {
+                greeted: Arc::new(Mutex::new(Vec::new())),
+            }),
+        )
+        .build();
+
+    assert!(
+        result.is_err(),
+        "registering the same plugin twice should fail at build() with a conflict error"
+    );
+}

--- a/tests/integration/wasm_plugin_test.rs
+++ b/tests/integration/wasm_plugin_test.rs
@@ -1,0 +1,304 @@
+//! Integration test — WasmPlugin (Option C, DD-021)
+//!
+//! Exercises the full chain `CliBuilder -> register_wasm_plugin() -> build()
+//! -> CliApp -> run_cli()` using only the crate's public API, with real
+//! `.wasm` modules written to disk via `tempfile::NamedTempFile` — exactly
+//! as a downstream application loading a third-party plugin would.
+//!
+//! Unit tests in `src/plugin/wasm.rs` already cover `WasmPlugin` and
+//! `WasmHandler` in isolation, using `WasmPlugin::from_bytes()` directly.
+//! This file instead verifies the public entry point
+//! (`CliBuilder::register_wasm_plugin`, which loads from a file path) and
+//! that both mandatory and optional parts of the ABI contract
+//! (`WASM_PLUGIN_INTERFACE.md`) propagate correctly all the way up to
+//! `run_cli()`'s `Result`.
+//!
+//! Covered ABI surface:
+//! - Mandatory: `memory`, `dcli_alloc`, `dcli_dealloc`, the mapped business
+//!   function.
+//! - Optional: `dcli_last_error_message`.
+
+#![cfg(feature = "wasm-plugins")]
+
+use dynamic_cli::config::schema::{CommandDefinition, Metadata};
+use dynamic_cli::error::{DynamicCliError, WasmError};
+use dynamic_cli::prelude::*;
+use std::any::Any;
+use std::collections::HashMap;
+use std::io::Write;
+use tempfile::NamedTempFile;
+
+// ============================================================================
+// Test fixtures
+// ============================================================================
+
+#[derive(Default)]
+struct TestContext;
+
+impl ExecutionContext for TestContext {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+/// A user-defined handler, registered alongside a WASM plugin, to verify
+/// `register_wasm_plugin` and `register_handler` coexist in `build()`.
+struct NativeHandler;
+
+impl CommandHandler for NativeHandler {
+    fn execute(
+        &self,
+        _ctx: &mut dyn ExecutionContext,
+        _args: &HashMap<String, String>,
+    ) -> dynamic_cli::Result<()> {
+        Ok(())
+    }
+}
+
+/// Mandatory-only contract: `memory`, `dcli_alloc`, `dcli_dealloc`, and a
+/// business function `ok_handler` that always succeeds.
+///
+/// Allocation/deallocation use a fixed bump pointer at offset 1024 — valid
+/// for ABI-contract testing, not a realistic allocator.
+const WAT_SUCCESS: &str = r#"
+    (module
+        (memory (export "memory") 1)
+        (func (export "dcli_alloc") (param i32) (result i32)
+            i32.const 1024)
+        (func (export "dcli_dealloc") (param i32 i32))
+        (func (export "ok_handler") (param i32 i32) (result i32)
+            i32.const 0)
+    )
+"#;
+
+/// Mandatory-only contract, business function always fails with code 1,
+/// no optional `dcli_last_error_message` export.
+const WAT_ERROR_NO_MESSAGE: &str = r#"
+    (module
+        (memory (export "memory") 1)
+        (func (export "dcli_alloc") (param i32) (result i32)
+            i32.const 1024)
+        (func (export "dcli_dealloc") (param i32 i32))
+        (func (export "err_handler") (param i32 i32) (result i32)
+            i32.const 1)
+    )
+"#;
+
+/// Full contract: mandatory exports plus the optional
+/// `dcli_last_error_message`, pointing at a fixed string in a data segment.
+const WAT_ERROR_WITH_MESSAGE: &str = r#"
+    (module
+        (memory (export "memory") 1)
+        (data (i32.const 2048) "disk write failed")
+        (func (export "dcli_alloc") (param i32) (result i32)
+            i32.const 1024)
+        (func (export "dcli_dealloc") (param i32 i32))
+        (func (export "err_handler") (param i32 i32) (result i32)
+            i32.const 1)
+        (func (export "dcli_last_error_message") (result i32 i32)
+            i32.const 2048
+            i32.const 17)
+    )
+"#;
+
+/// Writes a WAT module to a temporary `.wasm` file and returns the handle.
+///
+/// `NamedTempFile` is used rather than `TempDir` + `File::create`, per the
+/// project's established testing convention (eliminates path race
+/// conditions under parallel test execution). The file extension does not
+/// matter to `wasmtime` — it accepts WAT text directly — but `.wasm` is used
+/// for realism, since real plugin files will have that extension.
+fn write_wat_to_temp_file(wat: &str) -> NamedTempFile {
+    let mut file = NamedTempFile::new().expect("failed to create temp file for WAT fixture");
+    file.write_all(wat.as_bytes())
+        .expect("failed to write WAT fixture to temp file");
+    file.flush().expect("failed to flush WAT fixture");
+    file
+}
+
+/// Builds a minimal config declaring a single command `run` bound to the
+/// given WASM implementation name.
+///
+/// Used by the success and error-path tests, which only need the WASM
+/// plugin's command to be present — declaring an extra required command
+/// here would force every test to also register a handler for it.
+fn test_config(wasm_implementation: &str) -> CommandsConfig {
+    CommandsConfig {
+        metadata: Metadata {
+            version: "1.0.0".to_string(),
+            prompt: "testapp".to_string(),
+            prompt_suffix: " > ".to_string(),
+        },
+        commands: vec![CommandDefinition {
+            name: "run".to_string(),
+            aliases: vec![],
+            description: "Invoke the WASM plugin".to_string(),
+            required: true,
+            arguments: vec![],
+            options: vec![],
+            implementation: wasm_implementation.to_string(),
+        }],
+        global_options: vec![],
+    }
+}
+
+/// Builds a config declaring both the WASM-backed `run` command and a
+/// `native` command bound to `NativeHandler`.
+///
+/// Used only by the coexistence test, which is the sole scenario requiring
+/// both a WASM plugin and a directly-registered handler in the same
+/// `CliApp`.
+fn test_config_with_native(wasm_implementation: &str) -> CommandsConfig {
+    CommandsConfig {
+        metadata: Metadata {
+            version: "1.0.0".to_string(),
+            prompt: "testapp".to_string(),
+            prompt_suffix: " > ".to_string(),
+        },
+        commands: vec![
+            CommandDefinition {
+                name: "run".to_string(),
+                aliases: vec![],
+                description: "Invoke the WASM plugin".to_string(),
+                required: true,
+                arguments: vec![],
+                options: vec![],
+                implementation: wasm_implementation.to_string(),
+            },
+            CommandDefinition {
+                name: "native".to_string(),
+                aliases: vec![],
+                description: "A directly-registered native command".to_string(),
+                required: true,
+                arguments: vec![],
+                options: vec![],
+                implementation: "native_handler".to_string(),
+            },
+        ],
+        global_options: vec![],
+    }
+}
+
+// ============================================================================
+// Tests — mandatory contract, success path
+// ============================================================================
+
+/// A WASM module implementing only the mandatory ABI exports executes
+/// successfully through the full chain: `register_wasm_plugin` -> `build`
+/// -> `run_cli`.
+#[test]
+fn wasm_plugin_success_executes_via_full_chain() {
+    let wasm_file = write_wat_to_temp_file(WAT_SUCCESS);
+
+    let app = CliBuilder::new()
+        .config(test_config("ok_handler"))
+        .context(Box::new(TestContext))
+        .register_wasm_plugin(wasm_file.path(), &[("ok_handler", "ok_handler")])
+        .expect("loading a module with all mandatory exports should succeed")
+        .build()
+        .expect("build should succeed with a valid WASM plugin registered");
+
+    let result = app.run_cli(vec!["run".to_string()]);
+    assert!(
+        result.is_ok(),
+        "ok_handler should execute successfully end-to-end"
+    );
+}
+
+// ============================================================================
+// Tests — mandatory contract, error path (no optional export)
+// ============================================================================
+
+/// A WASM module that returns a non-zero error code, without exporting the
+/// optional `dcli_last_error_message`, propagates a `GuestError` with
+/// `message: None` all the way up to `run_cli()`'s `Result`.
+#[test]
+fn wasm_plugin_guest_error_without_message_propagates_via_full_chain() {
+    let wasm_file = write_wat_to_temp_file(WAT_ERROR_NO_MESSAGE);
+
+    let app = CliBuilder::new()
+        .config(test_config("err_handler"))
+        .context(Box::new(TestContext))
+        .register_wasm_plugin(wasm_file.path(), &[("err_handler", "err_handler")])
+        .expect("loading a module with all mandatory exports should succeed")
+        .build()
+        .expect("build should succeed — mandatory contract is satisfied");
+
+    let result = app.run_cli(vec!["run".to_string()]);
+    assert!(result.is_err(), "err_handler should propagate as an error");
+
+    match result.unwrap_err() {
+        DynamicCliError::Wasm(WasmError::GuestError { code, message }) => {
+            assert_eq!(code, 1);
+            assert!(
+                message.is_none(),
+                "no dcli_last_error_message export — message must be None, not invented"
+            );
+        }
+        other => panic!("expected DynamicCliError::Wasm(GuestError), got: {other:?}"),
+    }
+}
+
+// ============================================================================
+// Tests — full contract, error path (optional export present)
+// ============================================================================
+
+/// A WASM module that returns a non-zero error code AND exports the
+/// optional `dcli_last_error_message` propagates the detailed message all
+/// the way up to `run_cli()`'s `Result` — not just at the `WasmHandler`
+/// unit level.
+#[test]
+fn wasm_plugin_guest_error_with_message_propagates_via_full_chain() {
+    let wasm_file = write_wat_to_temp_file(WAT_ERROR_WITH_MESSAGE);
+
+    let app = CliBuilder::new()
+        .config(test_config("err_handler"))
+        .context(Box::new(TestContext))
+        .register_wasm_plugin(wasm_file.path(), &[("err_handler", "err_handler")])
+        .expect("loading a module with mandatory + optional exports should succeed")
+        .build()
+        .expect("build should succeed");
+
+    let result = app.run_cli(vec!["run".to_string()]);
+    assert!(result.is_err(), "err_handler should propagate as an error");
+
+    match result.unwrap_err() {
+        DynamicCliError::Wasm(WasmError::GuestError { code, message }) => {
+            assert_eq!(code, 1);
+            assert_eq!(
+                message,
+                Some("disk write failed".to_string()),
+                "dcli_last_error_message export should be read and surfaced end-to-end"
+            );
+        }
+        other => panic!("expected DynamicCliError::Wasm(GuestError), got: {other:?}"),
+    }
+}
+
+// ============================================================================
+// Tests — coexistence with a native handler
+// ============================================================================
+
+/// `register_wasm_plugin` and `register_handler` coexist in the same
+/// `CliApp`, each dispatching to its own implementation correctly.
+#[test]
+fn wasm_plugin_coexists_with_native_handler() {
+    let wasm_file = write_wat_to_temp_file(WAT_SUCCESS);
+
+    let app = CliBuilder::new()
+        .config(test_config_with_native("ok_handler"))
+        .context(Box::new(TestContext))
+        .register_wasm_plugin(wasm_file.path(), &[("ok_handler", "ok_handler")])
+        .expect("loading a module with all mandatory exports should succeed")
+        .register_handler("native_handler", Box::new(NativeHandler))
+        .build()
+        .expect("build should succeed with both a WASM plugin and a native handler");
+
+    assert!(
+        app.run_cli(vec!["run".to_string()]).is_ok(),
+        "WASM-backed 'run' command should execute"
+    );
+}


### PR DESCRIPTION
## Summary

Merges the `update/0.4.0` branch — the complete v0.4.0 Plugin System cycle — into `staging/0.4.0` for a dry-run merge against current `master` before the final PR to `master`.

Implements [DD-021](https://github.com/biface/dcli/issues/10): a static Update/0.4.0 plugin mechanism (`Plugin` trait, `SystemPlugin`) and a sandboxed WASM plugin mechanism (`WasmPlugin`, feature `wasm-plugins`), with dynamic `libloading` (Option B) permanently excluded.

Closes #22, closes #23.

## What's included

### Static plugins (Option A)
- `Plugin` trait (`src/plugin/mod.rs`) — declarative handler contribution, framework-controlled registration, conflict detection at `build()`.
- `SystemPlugin` (`src/plugin/system.rs`) — `system_help`/`system_version`/`system_exit`, with an optional shutdown callback (`with_exit   _fn`).
- `CliBuilder::register_plugin()`.

### WASM plugins (Option C, opt-in via `wasm-plugins`)
- `WasmPlugin` (`src/plugin/wasm.rs`) — sandboxed `.wasm`/`.wat` loading via `wasmtime`, mandatory ABI exports validated at load time (`memory`, `dcli_alloc`, `dcli_dealloc`), optional `dcli_last_error_message`. `dcli_dealloc` called on every exit path, including guest errors.
- `WasmError` (`src/error/types.rs`) — typed error category, feature-gated.
- `CliBuilder::register_wasm_plugin(path, function_map)` — `function_map` mandatory (no safe default for an empty mapping).
- `wasmtime = "45.0.0"` as an optional dependency — zero cost when the feature is disabled.

### Tests
- `tests/integration/system_plugin_test.rs` — 5 tests, full `CliBuilder → build() → CliApp → run_cli()` chain.
- `tests/integration/wasm_plugin_test.rs` — 4 tests, real `.wasm` files via `NamedempFile`, covering the full ABI surface (success, guest error with/without optional message, coexistence with a native handler).
- `ci.yml` / `coverage.yml` extended to exercise `--features wasm-plugins` explicitly.

### Documentation
- `PLUGIN_GUIDE.md` / `.fr.md` — full plugin authoring guide: common YAML contract, static plugins with a `chrom-rs`-grounded example, complete WASM ABI contract, host/guest terminology, restrictions vs. limitations.
- `CHANGELOG.md`, `PROJECT_STATUS.md`, `DESIGN_DECISIONS.md` updated for the v0.4.0 cycle close.

## Breaking changes

None. `register_plugin()` and `register_wasm_plugin()` are additive. `wasm-plugins` is an opt-in feature flag; `wasmtime` is never pulled in by default.

## Quality gates

| Gate | Command | Status |
|------|---------|--------|
| Clippy (default) | `cargo clippy -- -D warnings` | ✅ |
| Clippy (`wasm-plugins`) | `cargo clippy --features wasm-plugins -- -D warnings` | ✅ |
| Tests (default) | `cargo test` | ✅ |
| Tests (`wasm-plugins`) | `cargo test --features wasm-plugins` | ✅ |
| Doc-tests | `cargo test --doc` (both feature sets) | ✅ |
| Coverage | `cargo llvm-cov`, both feature sets, CI-enforced | ✅ |

## Purpose of this merge

This PR targets `staging/0.4.0` (branched from current `master`), not `master` directly — it is the dry-run merge that surfaces any conflict with `master` before the final release PR. No conflict resolution is expected; if any arises, resolve here rather than carrying it into the final PR.

## Follow-up

Granular static plugins and new official static plugins- (`SysInfoPlugin`, `EnvPlugin`, `ConfigPlugin`) deferred to-
**v0.7.0 · Static Plugin Library** — see linked triage issue.-