### PR TITLE
Integrate v0.6.0 — Advanced Options (code + docs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,37 +21,132 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.6.0] - Planned (Q1 2027)
+## [0.6.0] - 2026-07-24 *(date to confirm at tag/publish time)*
 
-**Theme**: Polish & Advanced Features  
-**Estimated Effort**: 4-6 weeks  
-**Dependencies**: None
+**Theme**: Advanced Options — Repeatable Options with Typed Sub-Parameters
+**Decision**: [DD-024](https://github.com/biface/dcli/issues/21)
 
-### Planned
+### Added
 
-#### Configuration Management
-- **Configuration hot-reload**: Watch config file and reload without restart
-  - File system watching with `notify` crate
-  - Graceful handler replacement
-  - Validation before applying changes
-  - Rollback on errors
+#### Repeatable options (`OptionDefinition::repeatable`)
+- **`OptionDefinition` gains two additive fields** (`src/config/schema.rs`):
+  ```rust
+  #[serde(default)]
+  pub repeatable: bool,
 
-#### Customization
-- **Color scheme customization**: User-defined color themes
-  - Theme definition in config file
-  - Pre-defined themes (dark, light, high-contrast)
-  - Per-element color control (errors, warnings, prompts, etc.)
-  - Support for RGB and named colors
+  #[serde(default)]
+  pub option_parameters: HashMap<String, Vec<ArgumentDefinition>>,
+  ```
+  `choices` doubles as the set of valid discriminants when `repeatable: true`
+  — no change to its existing meaning for scalar options. Both fields
+  default to `false` / empty, so no existing YAML config breaks.
+- **Config-load-time validation** (`src/config/validator.rs::validate_options()`):
+  `repeatable: true` requires non-empty `choices`; `option_parameters` keys
+  must equal `choices` exactly (no orphan key, no undeclared discriminant);
+  each `option_parameters[discriminant]` is validated via the existing
+  `validate_argument_names` / `validate_argument_types` (explicitly *not*
+  `validate_argument_ordering`, meaningless for named `key=value` pairs);
+  `repeatable: false` with non-empty `option_parameters` is rejected;
+  `repeatable: true` with `default: Some(_)` is rejected — a repeatable
+  option's absence means zero occurrences, not an implicit one.
+- **New `ParseError` variants** (`src/error/types.rs`): `UnknownOptionParameter`,
+  `MissingRequiredOptionParameter`, `UnknownDiscriminant`,
+  `DuplicateOptionOccurrence` — each with an actionable `suggestion`
+  pointing at `--help`, consistent with the DD-011 convention.
+- **Parser support** (`src/parser/cli_parser.rs`): new `OptionOccurrence`
+  and `ParsedValue::{Scalar, Repeated}` types; `--output csv file=... [k=v ...]`
+  accumulates into `Vec<OptionOccurrence>` in command-line order. Two
+  occurrences of the same discriminant with different `key=value` pairs are
+  both kept; identical occurrences are rejected
+  (`DuplicateOptionOccurrence`) — partially-overlapping occurrences are
+  *not* framework-rejected, since `dynamic-cli` has no way to know which
+  key is domain-significant; that stays the handler's responsibility.
 
-#### REPL Enhancements
-- **Command history search**: Fuzzy search in history (Ctrl+R)
-- **Multi-line command support**: Continue commands across lines with `\`
-- **Command macros**: Define custom shortcuts in config
+### Changed — Breaking
 
-#### Quality of Life
-- **Verbose mode**: `-v`/`--verbose` for detailed output
-- **Quiet mode**: `-q`/`--quiet` for minimal output
-- **Debug mode**: `--debug` for troubleshooting
+- **`CommandHandler::execute` / `validate` and `AsyncCommandHandler::execute`
+  / `validate`** now take `&ParsedArgs` instead of
+  `&HashMap<String, String>`. `HashMap<String, String>` could not represent
+  both a scalar option and a repeated-occurrence option in the same map;
+  `validate()` moves alongside `execute()` so a handler sees the same
+  argument shape in both — otherwise it could not validate repeatable-option
+  occurrences before `execute()` runs.
+
+  ```rust
+  pub struct ParsedArgs(HashMap<String, ParsedValue>);
+
+  impl ParsedArgs {
+      pub fn get_scalar(&self, name: &str) -> Option<&str> { .. }
+      pub fn get_repeated(&self, name: &str) -> Option<&[OptionOccurrence]> { .. }
+      pub fn to_scalar_map(&self) -> HashMap<String, String> { .. }
+  }
+  ```
+
+  **Before**:
+  ```rust
+  impl CommandHandler for MyCommand {
+      fn execute(
+          &self,
+          context: &mut dyn ExecutionContext,
+          args: &HashMap<String, String>,
+      ) -> Result<()> {
+          let name = args.get("name").unwrap();
+          // ...
+      }
+  }
+  ```
+
+  **After**:
+  ```rust
+  impl CommandHandler for MyCommand {
+      fn execute(
+          &self,
+          context: &mut dyn ExecutionContext,
+          args: &ParsedArgs,
+      ) -> Result<()> {
+          let name = args.get_scalar("name").unwrap();
+          // ...
+      }
+  }
+  ```
+
+  For handlers that never use repeatable options, migration is close to a
+  find-and-replace: `args.get("x")` → `args.get_scalar("x")`. Subsystems
+  that predate DD-024 and still expect a flat `HashMap<String, String>`
+  (e.g. the WASM plugin ABI in `src/plugin/wasm.rs`, which serializes
+  arguments across the guest boundary) bridge via
+  `args.to_scalar_map()` rather than being rewritten — repeatable options
+  are silently dropped for those consumers, matching the pre-DD-024
+  behaviour they were built against.
+
+- All in-crate examples (`examples/*.rs`) and the `README.md` / `README.fr.md`
+  quick-start handler migrated to the new signature.
+
+**Deviation from the v0.5.0 roadmap note**: this signature change was
+previously expected to land at v1.0.0, batched with the removal of the
+`register()` / `get_handler()` / `register_handler()` deprecated aliases.
+It ships here instead, at v0.6.0, since DD-024 is itself a breaking change
+and batching it further only delays real-world validation against
+`chrom-rs`. The deprecated-alias removal is unaffected and still targets
+v1.0.0.
+
+### Documentation
+- **`CONFIG_SYNTAX_REFERENCE.md`** / **`.fr.md`**: new section on
+  `repeatable` and `option_parameters`, with the `--output csv file=...
+  resolution=...` / `--output plot file=...` worked example.
+- **`README.md`** / **`.fr.md`**: install snippet bumped to `0.6.0`;
+  quick-start handler example migrated to `ParsedArgs`.
+- **`DESIGN_DECISIONS.md`**: DD-024 moved from "decided — implementation
+  pending" to closed.
+
+**Breaking Changes**: Yes — every existing `CommandHandler` /
+`AsyncCommandHandler` implementation must migrate both `execute()` and
+`validate()`. `chrom-rs`'s migration is tracked separately in its own
+issue tracker.
+
+**Roadmap follow-up**: the `register()` / `get_handler()` /
+`register_handler()` deprecated aliases (introduced in v0.5.0) are still
+scheduled for removal at **v1.0.0**, unaffected by this release.
 
 ---
 
@@ -572,10 +667,10 @@ dynamic-cli/
 | **0.1.0** | Initial Release          | Complete framework                  | -         | ✅ Released           |
 | **0.2.0** | Help & Errors            | Built-in help, better errors        | 3-4 weeks | ✅ Released           |
 | **0.3.0** | Shell Completions        | REPL completion, secure history     | 3-4 weeks | ✅ Released           |
-| **0.4.0** | Plugin System            | Extensible handlers                 | 4-6 weeks | 🔵 Planned Q3 2026   |
-| **0.5.0** | Async Support            | Async handlers (optional)           | 4-6 weeks | 🔵 Planned Q4 2026   |
-| **0.6.0** | Advanced Options         | Repeatable options, typed sub-params| 4-6 weeks | 🔵 Planned Q1 2027   |
-| **1.0.0** | Stable                   | Production-ready, locked API        | -         | 🔵 Planned Q1 2028   |
+| **0.4.0** | Plugin System            | Extensible handlers                 | 4-6 weeks | ✅ Released           |
+| **0.5.0** | Async Support            | Async handlers (optional)           | 4-6 weeks | ✅ Released           |
+| **0.6.0** | Advanced Options         | Repeatable options, typed sub-params| 4-6 weeks | ✅ Released           |
+| **1.0.0** | Stable                   | Production-ready, locked API        | -         | 🔵 Planned            |
 
 ---
 

--- a/CONFIG_SYNTAX_REFERENCE.fr.md
+++ b/CONFIG_SYNTAX_REFERENCE.fr.md
@@ -17,6 +17,7 @@
 - [Définition de commande](#définition-de-commande)
 - [Arguments](#arguments)
 - [Options](#options)
+- [Options répétables](#options-répétables)
 - [Types d'arguments](#types-darguments)
 - [Règles de validation](#règles-de-validation)
 - [Exemple complet](#exemple-complet)
@@ -555,6 +556,127 @@ monapp lancer -n warn
 monapp lancer                   # Utilise la valeur par défaut : info
 monapp lancer -n invalide       # ERREUR : choix invalide
 ```
+
+---
+
+## Options répétables
+
+*Depuis la v0.6.0 ([DD-024](https://github.com/biface/dcli/issues/21)).*
+
+Une option répétable peut apparaître plusieurs fois sur la même ligne de
+commande. Chaque occurrence commence par un **discriminant** — un jeton nu
+immédiatement après le drapeau, tiré de `choices` — suivi de zéro ou
+plusieurs sous-paramètres `clé=valeur`. `dynamic-cli` accumule chaque
+occurrence dans l'ordre de la ligne de commande ; le handler les reçoit
+toutes.
+
+### Structure
+
+```yaml
+options:
+  - name: string                          # Requis
+    long: string                          # Optionnel
+    short: string                         # Optionnel
+    option_type: ArgumentType             # Requis
+    required: boolean                     # Requis
+    description: string                   # Requis
+    choices: [string]                     # Requis si repeatable — discriminants valides
+    repeatable: true                      # Requis pour activer ce comportement
+    option_parameters:                    # Requis — une entrée par discriminant
+      <discriminant>:
+        - name: string
+          arg_type: ArgumentType
+          required: boolean
+          description: string
+          validation: []                  # Optionnel
+          secure: false                   # Optionnel
+```
+
+### Règles
+
+- `choices` doit être non vide et liste les discriminants valides.
+- Les clés de `option_parameters` doivent correspondre **exactement** à
+  `choices` — aucune clé orpheline, aucun discriminant non déclaré. Le
+  chargement de la configuration échoue sinon.
+- Chaque entrée `option_parameters[discriminant]` est une
+  [`ArgumentDefinition`](#arguments) classique (mêmes champs que les
+  `arguments:` positionnels), mais seuls `name` / `arg_type` / `required` /
+  `description` / `validation` / `secure` ont un sens — l'ordre n'a aucun
+  effet puisque les sous-paramètres sont associés par clé, pas par
+  position.
+- `default` n'est **pas autorisé** quand `repeatable: true` : l'absence de
+  l'option signifie déjà zéro occurrence, une valeur par défaut implicite
+  serait ambiguë.
+- `option_parameters` sur une option avec `repeatable: false` (ou absent)
+  est une erreur de configuration.
+- Deux occurrences du même discriminant avec des paires `clé=valeur`
+  différentes sont toutes deux conservées. Deux occurrences **strictement
+  identiques** (même discriminant, mêmes paires clé=valeur) sont rejetées
+  — c'est le seul chevauchement que le framework peut détecter sans
+  connaissance du domaine ; les occurrences partiellement chevauchantes
+  (même `file`, `resolution` différente, par exemple) sont acceptées et
+  laissées à la charge du handler.
+
+### Exemple
+
+```yaml
+- name: "output"
+  long: "output"
+  option_type: "string"
+  required: false
+  description: "Écrit les résultats sous une ou plusieurs formes de sortie"
+  choices: ["csv", "plot"]
+  repeatable: true
+  option_parameters:
+    csv:
+      - name: "file"
+        arg_type: "path"
+        required: true
+        description: "Fichier CSV de destination"
+      - name: "resolution"
+        arg_type: "integer"
+        required: false
+        description: "Résolution du pas de temps"
+    plot:
+      - name: "file"
+        arg_type: "path"
+        required: true
+        description: "Fichier image de destination"
+```
+
+**Utilisation** :
+```bash
+monapp export --output csv file=resultats.csv resolution=100
+monapp export --output csv file=resultats.csv --output plot file=graphe.png
+monapp export --output csv file=a.csv --output csv file=b.csv   # les deux conservées — `file` différent
+monapp export --output csv file=a.csv --output csv file=a.csv   # ERREUR : DuplicateOptionOccurrence
+monapp export --output json file=out.json                       # ERREUR : UnknownDiscriminant
+monapp export --output csv                                      # ERREUR : MissingRequiredOptionParameter (file)
+monapp export --output csv file=a.csv depth=3                   # ERREUR : UnknownOptionParameter (depth)
+```
+
+### Côté handler
+
+`CommandHandler::execute` (et `validate`) reçoivent désormais une valeur
+`ParsedArgs` (voir la
+[documentation du module `executor`](https://docs.rs/dynamic-cli/latest/dynamic_cli/executor/))
+plutôt qu'une simple `HashMap<String, String>`, précisément pour pouvoir
+représenter les occurrences d'une option répétable aux côtés des options
+scalaires :
+
+```rust
+let occurrences = args.get_repeated("output").unwrap_or(&[]);
+for occ in occurrences {
+    match occ.discriminant.as_str() {
+        "csv" => { /* occ.params.get("file"), occ.params.get("resolution") */ }
+        "plot" => { /* occ.params.get("file") */ }
+        _ => unreachable!(), // la validation de config a déjà rejeté les autres discriminants
+    }
+}
+```
+
+Voir `CHANGELOG.md` (v0.6.0) pour le chemin de migration complet
+`HashMap<String, String>` → `ParsedArgs` des handlers existants.
 
 ---
 

--- a/CONFIG_SYNTAX_REFERENCE.md
+++ b/CONFIG_SYNTAX_REFERENCE.md
@@ -17,6 +17,7 @@
 - [Command Definition](#command-definition)
 - [Arguments](#arguments)
 - [Options](#options)
+- [Repeatable Options](#repeatable-options)
 - [Argument Types](#argument-types)
 - [Validation Rules](#validation-rules)
 - [Complete Example](#complete-example)
@@ -554,6 +555,121 @@ myapp run -l warn
 myapp run                   # Uses default: info
 myapp run -l invalid        # ERROR: invalid choice
 ```
+
+---
+
+## Repeatable Options
+
+*Since v0.6.0 ([DD-024](https://github.com/biface/dcli/issues/21)).*
+
+A repeatable option can appear more than once on the same command line.
+Each occurrence starts with a **discriminant** — a bare token immediately
+after the flag, drawn from `choices` — followed by zero or more `key=value`
+sub-parameters. `dynamic-cli` accumulates every occurrence in command-line
+order; the handler receives them all.
+
+### Structure
+
+```yaml
+options:
+  - name: string                          # Required
+    long: string                          # Optional
+    short: string                         # Optional
+    option_type: ArgumentType             # Required
+    required: boolean                     # Required
+    description: string                   # Required
+    choices: [string]                     # Required when repeatable — valid discriminants
+    repeatable: true                      # Required to enable this behaviour
+    option_parameters:                    # Required — one entry per discriminant
+      <discriminant>:
+        - name: string
+          arg_type: ArgumentType
+          required: boolean
+          description: string
+          validation: []                  # Optional
+          secure: false                   # Optional
+```
+
+### Rules
+
+- `choices` must be non-empty and lists the valid discriminants.
+- `option_parameters` keys must match `choices` **exactly** — no orphan
+  key, no discriminant left undeclared. Config loading fails otherwise.
+- Each `option_parameters[discriminant]` entry is a regular
+  [`ArgumentDefinition`](#arguments) (same fields as positional
+  `arguments:`), but only `name` / `arg_type` / `required` / `description`
+  / `validation` / `secure` are meaningful — ordering has no effect, since
+  sub-parameters are matched by key, not position.
+- `default` is **not allowed** when `repeatable: true`: the option's
+  absence already means zero occurrences, so an implicit default would be
+  ambiguous.
+- `option_parameters` on an option with `repeatable: false` (or absent) is
+  a config error.
+- Two occurrences of the same discriminant with different `key=value`
+  pairs are both kept. Two occurrences that are **strictly identical**
+  (same discriminant, same key=value pairs) are rejected — this is the
+  only overlap the framework can detect without domain knowledge;
+  partially-overlapping occurrences (same `file`, different `resolution`,
+  say) are accepted and left to the handler to reconcile.
+
+### Example
+
+```yaml
+- name: "output"
+  long: "output"
+  option_type: "string"
+  required: false
+  description: "Write results in one or more output kinds"
+  choices: ["csv", "plot"]
+  repeatable: true
+  option_parameters:
+    csv:
+      - name: "file"
+        arg_type: "path"
+        required: true
+        description: "Destination CSV file"
+      - name: "resolution"
+        arg_type: "integer"
+        required: false
+        description: "Time-step resolution"
+    plot:
+      - name: "file"
+        arg_type: "path"
+        required: true
+        description: "Destination image file"
+```
+
+**Usage**:
+```bash
+myapp export --output csv file=results.csv resolution=100
+myapp export --output csv file=results.csv --output plot file=chart.png
+myapp export --output csv file=a.csv --output csv file=b.csv   # both kept — different `file`
+myapp export --output csv file=a.csv --output csv file=a.csv   # ERROR: DuplicateOptionOccurrence
+myapp export --output json file=out.json                       # ERROR: UnknownDiscriminant
+myapp export --output csv                                      # ERROR: MissingRequiredOptionParameter (file)
+myapp export --output csv file=a.csv depth=3                   # ERROR: UnknownOptionParameter (depth)
+```
+
+### Handler side
+
+`CommandHandler::execute` (and `validate`) receive a `ParsedArgs` value
+(see the [`executor` module docs](https://docs.rs/dynamic-cli/latest/dynamic_cli/executor/))
+rather than a flat `HashMap<String, String>`, precisely so a repeatable option's occurrences
+can be represented alongside scalar options:
+
+```rust
+let occurrences = args.get_repeated("output").unwrap_or(&[]);
+for occ in occurrences {
+    match occ.discriminant.as_str() {
+        "csv" => { /* occ.params.get("file"), occ.params.get("resolution") */ }
+        "plot" => { /* occ.params.get("file") */ }
+        _ => unreachable!(), // config validation already rejected other discriminants
+    }
+}
+```
+
+See `CHANGELOG.md` (v0.6.0) for the full `HashMap<String, String>` →
+`ParsedArgs` migration path for existing handlers.
 
 ---
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -35,10 +35,10 @@ Ajoutez à votre `Cargo.toml` :
 
 ```toml
 [dependencies]
-dynamic-cli = "0.5.0"
+dynamic-cli = "0.6.0"
 
 # Optionnel — plugins WASM sandboxés (voir Système de Plugins ci-dessous)
-# dynamic-cli = { version = "0.5.0", features = ["wasm-plugins"] }
+# dynamic-cli = { version = "0.6.0", features = ["wasm-plugins"] }
 ```
 
 ### Exemple Basique
@@ -83,7 +83,6 @@ global_options: []
 
 ```rust
 use dynamic_cli::prelude::*;
-use std::collections::HashMap;
 
 // Définissez le contexte de votre application
 #[derive(Default)]
@@ -103,10 +102,10 @@ impl CommandHandler for CommandeSaluer {
     fn execute(
         &self,
         _context: &mut dyn ExecutionContext,
-        args: &HashMap<String, String>,
+        args: &ParsedArgs,
     ) -> dynamic_cli::Result<()> {
-        let nom = args.get("nom").unwrap();
-        let fort = args.get("fort").map(|v| v == "true").unwrap_or(false);
+        let nom = args.get_scalar("nom").unwrap();
+        let fort = args.get_scalar("fort").map(|v| v == "true").unwrap_or(false);
         
         let salutation = format!("Bonjour, {} !", nom);
         println!("{}", if fort { salutation.to_uppercase() } else { salutation });
@@ -369,4 +368,4 @@ Si vous trouvez dynamic-cli utile, veuillez :
 - 📢 **Partager** avec d'autres qui pourraient le trouver utile
 - 📝 **Écrire** un article de blog ou un tutoriel !
 
-**Dernière mise à jour** : 2026-06-19
+**Dernière mise à jour** : 2026-07-24

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-dynamic-cli = "0.5.0"
+dynamic-cli = "0.6.0"
 
 # Optional — sandboxed WASM plugins (see Plugin System below)
-# dynamic-cli = { version = "0.5.0", features = ["wasm-plugins"] }
+# dynamic-cli = { version = "0.6.0", features = ["wasm-plugins"] }
 ```
 
 ### Basic Example
@@ -83,7 +83,6 @@ global_options: []
 
 ```rust
 use dynamic_cli::prelude::*;
-use std::collections::HashMap;
 
 // Define your application context
 #[derive(Default)]
@@ -103,10 +102,10 @@ impl CommandHandler for GreetCommand {
     fn execute(
         &self,
         _context: &mut dyn ExecutionContext,
-        args: &HashMap<String, String>,
+        args: &ParsedArgs,
     ) -> dynamic_cli::Result<()> {
-        let name = args.get("name").unwrap();
-        let loud = args.get("loud").map(|v| v == "true").unwrap_or(false);
+        let name = args.get_scalar("name").unwrap();
+        let loud = args.get_scalar("loud").map(|v| v == "true").unwrap_or(false);
         
         let greeting = format!("Hello, {}!", name);
         println!("{}", if loud { greeting.to_uppercase() } else { greeting });
@@ -367,4 +366,4 @@ If you find dynamic-cli useful, please:
 - 📢 **Share** it with others who might find it useful
 - 📝 **Write** a blog post or tutorial!
 
-**Last updated**: 2026-06-19
+**Last updated**: 2026-07-24

--- a/examples/README.md
+++ b/examples/README.md
@@ -315,7 +315,7 @@ impl CommandHandler for MyCommand {
     fn execute(
         &self,
         context: &mut dyn ExecutionContext,
-        args: &HashMap<String, String>,
+        args: &ParsedArgs,
     ) -> Result<()> {
         // Your command logic
         Ok(())

--- a/examples/async_token_demo.rs
+++ b/examples/async_token_demo.rs
@@ -16,7 +16,6 @@ use dynamic_cli::config::schema::{CommandDefinition, Metadata};
 use dynamic_cli::executor::AsyncCommandHandler;
 use dynamic_cli::prelude::*;
 use std::any::Any;
-use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
 #[derive(Default)]
@@ -43,7 +42,7 @@ impl AsyncCommandHandler for TokenFetchHandler {
     async fn execute(
         &self,
         _ctx: &mut dyn ExecutionContext,
-        _args: &HashMap<String, String>,
+        _args: &ParsedArgs,
     ) -> dynamic_cli::Result<()> {
         println!("Fetching token... (this genuinely takes 10 seconds)");
         let started = Instant::now();

--- a/examples/file_manager.rs
+++ b/examples/file_manager.rs
@@ -16,7 +16,6 @@
 //! ```
 
 use dynamic_cli::prelude::*;
-use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -50,11 +49,7 @@ impl ExecutionContext for FileManagerContext {
 struct ListCommand;
 
 impl CommandHandler for ListCommand {
-    fn execute(
-        &self,
-        context: &mut dyn ExecutionContext,
-        args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, context: &mut dyn ExecutionContext, args: &ParsedArgs) -> Result<()> {
         let ctx =
             dynamic_cli::context::downcast_mut::<FileManagerContext>(context).ok_or_else(|| {
                 DynamicCliError::Execution(
@@ -66,7 +61,7 @@ impl CommandHandler for ListCommand {
             })?;
 
         // Get directory path
-        let dir = args.get("directory").map(|s| s.as_str()).unwrap_or(".");
+        let dir = args.get_scalar("directory").unwrap_or(".");
         let path = Path::new(dir);
 
         // Validate directory exists
@@ -150,11 +145,7 @@ impl CommandHandler for ListCommand {
 struct InfoCommand;
 
 impl CommandHandler for InfoCommand {
-    fn execute(
-        &self,
-        context: &mut dyn ExecutionContext,
-        args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, context: &mut dyn ExecutionContext, args: &ParsedArgs) -> Result<()> {
         let ctx =
             dynamic_cli::context::downcast_mut::<FileManagerContext>(context).ok_or_else(|| {
                 DynamicCliError::Execution(
@@ -165,7 +156,7 @@ impl CommandHandler for InfoCommand {
                 )
             })?;
 
-        let file = args.get("file").unwrap();
+        let file = args.get_scalar("file").unwrap();
         let path = Path::new(file);
 
         // Validate file exists
@@ -222,11 +213,7 @@ impl CommandHandler for InfoCommand {
 struct SearchCommand;
 
 impl CommandHandler for SearchCommand {
-    fn execute(
-        &self,
-        context: &mut dyn ExecutionContext,
-        args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, context: &mut dyn ExecutionContext, args: &ParsedArgs) -> Result<()> {
         let ctx =
             dynamic_cli::context::downcast_mut::<FileManagerContext>(context).ok_or_else(|| {
                 DynamicCliError::Execution(
@@ -237,8 +224,8 @@ impl CommandHandler for SearchCommand {
                 )
             })?;
 
-        let dir = args.get("directory").map(|s| s.as_str()).unwrap_or(".");
-        let pattern = args.get("pattern").map(|s| s.as_str()).unwrap_or("*");
+        let dir = args.get_scalar("directory").unwrap_or(".");
+        let pattern = args.get_scalar("pattern").unwrap_or("*");
 
         let path = Path::new(dir);
 
@@ -302,11 +289,7 @@ impl CommandHandler for SearchCommand {
 struct StatsCommand;
 
 impl CommandHandler for StatsCommand {
-    fn execute(
-        &self,
-        context: &mut dyn ExecutionContext,
-        _args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
         let ctx =
             dynamic_cli::context::downcast_ref::<FileManagerContext>(context).ok_or_else(|| {
                 DynamicCliError::Execution(

--- a/examples/rpn_calculator.rs
+++ b/examples/rpn_calculator.rs
@@ -38,7 +38,6 @@
 
 use dynamic_cli::prelude::*;
 use std::any::Any;
-use std::collections::HashMap;
 
 /// ================================================================================================
 /// Execution context
@@ -167,11 +166,7 @@ impl ExecutionContext for SimpleRpnContext {
 struct PushCommand;
 
 impl CommandHandler for PushCommand {
-    fn execute(
-        &self,
-        context: &mut dyn ExecutionContext,
-        args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, context: &mut dyn ExecutionContext, args: &ParsedArgs) -> Result<()> {
         let rpn_context = downcast_mut::<SimpleRpnContext>(context).ok_or_else(|| {
             DynamicCliError::Execution(dynamic_cli::error::ExecutionError::ContextDowncastFailed {
                 expected_type: "RPN Calculator context".to_string(),
@@ -180,7 +175,7 @@ impl CommandHandler for PushCommand {
         })?;
 
         // Parse the value arguments
-        let cli_value = args.get("value").ok_or_else(|| {
+        let cli_value = args.get_scalar("value").ok_or_else(|| {
             DynamicCliError::Parse(dynamic_cli::error::ParseError::MissingArgument {
                 argument: "value".to_string(),
                 command: "push".to_string(),
@@ -193,7 +188,7 @@ impl CommandHandler for PushCommand {
             DynamicCliError::Parse(dynamic_cli::error::ParseError::TypeParseError {
                 arg_name: "value".to_string(),
                 expected_type: "float".to_string(),
-                value: cli_value.clone(),
+                value: cli_value.to_string(),
                 details: Some("not a valid number".to_string()),
             })
         })?;
@@ -211,11 +206,7 @@ impl CommandHandler for PushCommand {
 struct PopCommand;
 
 impl CommandHandler for PopCommand {
-    fn execute(
-        &self,
-        context: &mut dyn ExecutionContext,
-        args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
         let rpn_ctx = downcast_mut::<SimpleRpnContext>(context).ok_or_else(|| {
             DynamicCliError::Execution(dynamic_cli::error::ExecutionError::ContextDowncastFailed {
                 expected_type: "RPN Calculator context".to_string(),
@@ -237,11 +228,7 @@ impl CommandHandler for PopCommand {
 struct LastXCommand;
 
 impl CommandHandler for LastXCommand {
-    fn execute(
-        &self,
-        context: &mut dyn ExecutionContext,
-        args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
         let rpn_ctx = downcast_mut::<SimpleRpnContext>(context).ok_or_else(|| {
             DynamicCliError::Execution(dynamic_cli::error::ExecutionError::ContextDowncastFailed {
                 expected_type: "RPN Calculator context".to_string(),
@@ -263,11 +250,7 @@ impl CommandHandler for LastXCommand {
 struct SwapCommand;
 
 impl CommandHandler for SwapCommand {
-    fn execute(
-        &self,
-        context: &mut dyn ExecutionContext,
-        args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
         let rpn_ctx = downcast_mut::<SimpleRpnContext>(context).ok_or_else(|| {
             DynamicCliError::Execution(dynamic_cli::error::ExecutionError::ContextDowncastFailed {
                 expected_type: "RPN Calculator context".to_string(),
@@ -289,11 +272,7 @@ impl CommandHandler for SwapCommand {
 struct PeekCommand;
 
 impl CommandHandler for PeekCommand {
-    fn execute(
-        &self,
-        context: &mut dyn ExecutionContext,
-        args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
         let rpn_ctx = downcast_mut::<SimpleRpnContext>(context).ok_or_else(|| {
             DynamicCliError::Execution(dynamic_cli::error::ExecutionError::ContextDowncastFailed {
                 expected_type: "RPN Calculator context".to_string(),
@@ -317,11 +296,7 @@ impl CommandHandler for PeekCommand {
 struct ShowCommand;
 
 impl CommandHandler for ShowCommand {
-    fn execute(
-        &self,
-        context: &mut dyn ExecutionContext,
-        args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
         let rpn_ctx = downcast_mut::<SimpleRpnContext>(context).ok_or_else(|| {
             DynamicCliError::Execution(dynamic_cli::error::ExecutionError::ContextDowncastFailed {
                 expected_type: "RPN Calculator context".to_string(),
@@ -341,11 +316,7 @@ impl CommandHandler for ShowCommand {
 struct ClearCommand;
 
 impl CommandHandler for ClearCommand {
-    fn execute(
-        &self,
-        context: &mut dyn ExecutionContext,
-        args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
         let rpn_ctx = downcast_mut::<SimpleRpnContext>(context).ok_or_else(|| {
             DynamicCliError::Execution(dynamic_cli::error::ExecutionError::ContextDowncastFailed {
                 expected_type: "RPN Calculator context".to_string(),
@@ -365,11 +336,7 @@ impl CommandHandler for ClearCommand {
 struct AddCommand;
 
 impl CommandHandler for AddCommand {
-    fn execute(
-        &self,
-        context: &mut dyn ExecutionContext,
-        args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
         let rpn_ctx = downcast_mut::<SimpleRpnContext>(context).ok_or_else(|| {
             DynamicCliError::Execution(dynamic_cli::error::ExecutionError::ContextDowncastFailed {
                 expected_type: "RPN Calculator context".to_string(),
@@ -388,11 +355,7 @@ impl CommandHandler for AddCommand {
 struct SubCommand;
 
 impl CommandHandler for SubCommand {
-    fn execute(
-        &self,
-        context: &mut dyn ExecutionContext,
-        args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
         let rpn_ctx = downcast_mut::<SimpleRpnContext>(context).ok_or_else(|| {
             DynamicCliError::Execution(dynamic_cli::error::ExecutionError::ContextDowncastFailed {
                 expected_type: "RPN Calculator context".to_string(),
@@ -412,11 +375,7 @@ impl CommandHandler for SubCommand {
 struct MulCommand;
 
 impl CommandHandler for MulCommand {
-    fn execute(
-        &self,
-        context: &mut dyn ExecutionContext,
-        args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
         let rpn_ctx = downcast_mut::<SimpleRpnContext>(context).ok_or_else(|| {
             DynamicCliError::Execution(dynamic_cli::error::ExecutionError::ContextDowncastFailed {
                 expected_type: "RPN Calculator context".to_string(),
@@ -435,11 +394,7 @@ impl CommandHandler for MulCommand {
 struct DivCommand;
 
 impl CommandHandler for DivCommand {
-    fn execute(
-        &self,
-        context: &mut dyn ExecutionContext,
-        args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
         let rpn_ctx = downcast_mut::<SimpleRpnContext>(context).ok_or_else(|| {
             DynamicCliError::Execution(dynamic_cli::error::ExecutionError::ContextDowncastFailed {
                 expected_type: "RPN Calculator context".to_string(),
@@ -459,11 +414,7 @@ impl CommandHandler for DivCommand {
 struct LnFunction;
 
 impl CommandHandler for LnFunction {
-    fn execute(
-        &self,
-        context: &mut dyn ExecutionContext,
-        args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
         let rpn_ctx = downcast_mut::<SimpleRpnContext>(context).ok_or_else(|| {
             DynamicCliError::Execution(dynamic_cli::error::ExecutionError::ContextDowncastFailed {
                 expected_type: "RPN Calculator context".to_string(),
@@ -514,6 +465,7 @@ fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
     use std::f64::consts::PI;
     #[test]
     fn test_rpn_context_push_pop() {
@@ -577,6 +529,7 @@ mod tests {
         let handler = PushCommand;
 
         _args.insert("value".to_string(), "45.0".to_string());
+        let _args = ParsedArgs::from_scalars(_args);
         handler
             .execute(rpn_execution_test.as_mut(), &_args)
             .unwrap();
@@ -593,6 +546,7 @@ mod tests {
         ctx_test.push_x(1.0);
         let mut rpn_execution_test: Box<dyn ExecutionContext> = Box::new(ctx_test);
         let args = HashMap::new();
+        let args = ParsedArgs::from_scalars(args);
         let handler = LnFunction;
 
         handler.execute(rpn_execution_test.as_mut(), &args).unwrap();
@@ -613,7 +567,10 @@ mod tests {
         let push_cmd = PushCommand;
         _args.insert("value".to_string(), "45.0".to_string());
         push_cmd
-            .execute(rpn_execution_test.as_mut(), &_args)
+            .execute(
+                rpn_execution_test.as_mut(),
+                &ParsedArgs::from_scalars(_args.clone()),
+            )
             .unwrap();
         let ctx_copy =
             dynamic_cli::context::downcast_ref::<SimpleRpnContext>(rpn_execution_test.as_ref())
@@ -621,7 +578,10 @@ mod tests {
         assert_eq!(ctx_copy.peek(), Some(45.0));
         _args.insert("value".to_string(), "5".to_string());
         push_cmd
-            .execute(rpn_execution_test.as_mut(), &_args)
+            .execute(
+                rpn_execution_test.as_mut(),
+                &ParsedArgs::from_scalars(_args.clone()),
+            )
             .unwrap();
         let ctx_copy =
             dynamic_cli::context::downcast_ref::<SimpleRpnContext>(rpn_execution_test.as_ref())
@@ -631,7 +591,10 @@ mod tests {
 
         let add_command = AddCommand;
         add_command
-            .execute(rpn_execution_test.as_mut(), &_args)
+            .execute(
+                rpn_execution_test.as_mut(),
+                &ParsedArgs::from_scalars(_args),
+            )
             .unwrap();
         let ctx_test =
             dynamic_cli::context::downcast_ref::<SimpleRpnContext>(rpn_execution_test.as_ref())

--- a/examples/simple_calculator.rs
+++ b/examples/simple_calculator.rs
@@ -15,7 +15,6 @@
 //! ```
 
 use dynamic_cli::prelude::*;
-use std::collections::HashMap;
 
 // ============================================================================
 // EXECUTION CONTEXT
@@ -46,11 +45,7 @@ impl ExecutionContext for CalculatorContext {
 struct AddCommand;
 
 impl CommandHandler for AddCommand {
-    fn execute(
-        &self,
-        context: &mut dyn ExecutionContext,
-        args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, context: &mut dyn ExecutionContext, args: &ParsedArgs) -> Result<()> {
         let ctx =
             dynamic_cli::context::downcast_mut::<CalculatorContext>(context).ok_or_else(|| {
                 DynamicCliError::Execution(
@@ -62,8 +57,8 @@ impl CommandHandler for AddCommand {
             })?;
 
         // Parse arguments
-        let a = dynamic_cli::parse_float(args.get("a").unwrap(), "a")?;
-        let b = dynamic_cli::parse_float(args.get("b").unwrap(), "b")?;
+        let a = dynamic_cli::parse_float(args.get_scalar("a").unwrap(), "a")?;
+        let b = dynamic_cli::parse_float(args.get_scalar("b").unwrap(), "b")?;
 
         // Calculate
         let result = a + b;
@@ -81,11 +76,7 @@ impl CommandHandler for AddCommand {
 struct SubtractCommand;
 
 impl CommandHandler for SubtractCommand {
-    fn execute(
-        &self,
-        context: &mut dyn ExecutionContext,
-        args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, context: &mut dyn ExecutionContext, args: &ParsedArgs) -> Result<()> {
         let ctx =
             dynamic_cli::context::downcast_mut::<CalculatorContext>(context).ok_or_else(|| {
                 DynamicCliError::Execution(
@@ -96,8 +87,8 @@ impl CommandHandler for SubtractCommand {
                 )
             })?;
 
-        let a = dynamic_cli::parse_float(args.get("a").unwrap(), "a")?;
-        let b = dynamic_cli::parse_float(args.get("b").unwrap(), "b")?;
+        let a = dynamic_cli::parse_float(args.get_scalar("a").unwrap(), "a")?;
+        let b = dynamic_cli::parse_float(args.get_scalar("b").unwrap(), "b")?;
 
         let result = a - b;
         ctx.last_result = Some(result);
@@ -113,11 +104,7 @@ impl CommandHandler for SubtractCommand {
 struct MultiplyCommand;
 
 impl CommandHandler for MultiplyCommand {
-    fn execute(
-        &self,
-        context: &mut dyn ExecutionContext,
-        args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, context: &mut dyn ExecutionContext, args: &ParsedArgs) -> Result<()> {
         let ctx =
             dynamic_cli::context::downcast_mut::<CalculatorContext>(context).ok_or_else(|| {
                 DynamicCliError::Execution(
@@ -128,8 +115,8 @@ impl CommandHandler for MultiplyCommand {
                 )
             })?;
 
-        let a = dynamic_cli::parse_float(args.get("a").unwrap(), "a")?;
-        let b = dynamic_cli::parse_float(args.get("b").unwrap(), "b")?;
+        let a = dynamic_cli::parse_float(args.get_scalar("a").unwrap(), "a")?;
+        let b = dynamic_cli::parse_float(args.get_scalar("b").unwrap(), "b")?;
 
         let result = a * b;
         ctx.last_result = Some(result);
@@ -145,11 +132,7 @@ impl CommandHandler for MultiplyCommand {
 struct DivideCommand;
 
 impl CommandHandler for DivideCommand {
-    fn execute(
-        &self,
-        context: &mut dyn ExecutionContext,
-        args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, context: &mut dyn ExecutionContext, args: &ParsedArgs) -> Result<()> {
         let ctx =
             dynamic_cli::context::downcast_mut::<CalculatorContext>(context).ok_or_else(|| {
                 DynamicCliError::Execution(
@@ -160,8 +143,8 @@ impl CommandHandler for DivideCommand {
                 )
             })?;
 
-        let a = dynamic_cli::parse_float(args.get("a").unwrap(), "a")?;
-        let b = dynamic_cli::parse_float(args.get("b").unwrap(), "b")?;
+        let a = dynamic_cli::parse_float(args.get_scalar("a").unwrap(), "a")?;
+        let b = dynamic_cli::parse_float(args.get_scalar("b").unwrap(), "b")?;
 
         // Check for division by zero
         if b == 0.0 {
@@ -186,11 +169,7 @@ impl CommandHandler for DivideCommand {
 struct HistoryCommand;
 
 impl CommandHandler for HistoryCommand {
-    fn execute(
-        &self,
-        context: &mut dyn ExecutionContext,
-        _args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
         let ctx =
             dynamic_cli::context::downcast_ref::<CalculatorContext>(context).ok_or_else(|| {
                 DynamicCliError::Execution(
@@ -216,11 +195,7 @@ impl CommandHandler for HistoryCommand {
 struct ClearCommand;
 
 impl CommandHandler for ClearCommand {
-    fn execute(
-        &self,
-        context: &mut dyn ExecutionContext,
-        _args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
         let ctx =
             dynamic_cli::context::downcast_mut::<CalculatorContext>(context).ok_or_else(|| {
                 DynamicCliError::Execution(
@@ -243,11 +218,7 @@ impl CommandHandler for ClearCommand {
 struct LastCommand;
 
 impl CommandHandler for LastCommand {
-    fn execute(
-        &self,
-        context: &mut dyn ExecutionContext,
-        _args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
         let ctx =
             dynamic_cli::context::downcast_ref::<CalculatorContext>(context).ok_or_else(|| {
                 DynamicCliError::Execution(

--- a/examples/task_runner.rs
+++ b/examples/task_runner.rs
@@ -22,7 +22,6 @@
 use dynamic_cli::context::downcast_mut;
 use dynamic_cli::prelude::*;
 use dynamic_cli::utils::{is_blank, parse_int};
-use std::collections::HashMap;
 
 // ============================================================================
 // DOMAIN MODEL
@@ -248,11 +247,7 @@ struct TaskStats {
 struct AddCommand;
 
 impl CommandHandler for AddCommand {
-    fn execute(
-        &self,
-        context: &mut dyn ExecutionContext,
-        args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, context: &mut dyn ExecutionContext, args: &ParsedArgs) -> Result<()> {
         let ctx = downcast_mut::<TaskRunnerContext>(context).ok_or_else(|| {
             DynamicCliError::Execution(dynamic_cli::error::ExecutionError::ContextDowncastFailed {
                 expected_type: "TaskRunnerContext".to_string(),
@@ -261,7 +256,7 @@ impl CommandHandler for AddCommand {
         })?;
 
         // Get and validate description
-        let description = args.get("description").ok_or_else(|| {
+        let description = args.get_scalar("description").ok_or_else(|| {
             DynamicCliError::Parse(dynamic_cli::error::ParseError::MissingArgument {
                 argument: "description".to_string(),
                 command: "add".to_string(),
@@ -280,11 +275,11 @@ impl CommandHandler for AddCommand {
         }
 
         // Parse priority
-        let priority_str = args.get("priority").map(|s| s.as_str()).unwrap_or("medium");
+        let priority_str = args.get_scalar("priority").unwrap_or("medium");
         let priority = Priority::from_str(priority_str)?;
 
         // Add task
-        let id = ctx.add_task(description.clone(), priority);
+        let id = ctx.add_task(description.to_string(), priority);
 
         println!("✓ Task added with ID {}: {}", id, description);
         println!("  Priority: {}", priority.as_str());
@@ -297,11 +292,7 @@ impl CommandHandler for AddCommand {
 struct ListCommand;
 
 impl CommandHandler for ListCommand {
-    fn execute(
-        &self,
-        context: &mut dyn ExecutionContext,
-        args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, context: &mut dyn ExecutionContext, args: &ParsedArgs) -> Result<()> {
         let ctx = downcast_mut::<TaskRunnerContext>(context).ok_or_else(|| {
             DynamicCliError::Execution(dynamic_cli::error::ExecutionError::ContextDowncastFailed {
                 expected_type: "TaskRunnerContext".to_string(),
@@ -310,7 +301,7 @@ impl CommandHandler for ListCommand {
         })?;
 
         // Check if --all flag is present
-        let show_all = args.get("all").map(|v| v == "true").unwrap_or(false);
+        let show_all = args.get_scalar("all").map(|v| v == "true").unwrap_or(false);
 
         let tasks = if show_all {
             ctx.all_tasks()
@@ -348,11 +339,7 @@ impl CommandHandler for ListCommand {
 struct CompleteCommand;
 
 impl CommandHandler for CompleteCommand {
-    fn execute(
-        &self,
-        context: &mut dyn ExecutionContext,
-        args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, context: &mut dyn ExecutionContext, args: &ParsedArgs) -> Result<()> {
         let ctx = downcast_mut::<TaskRunnerContext>(context).ok_or_else(|| {
             DynamicCliError::Execution(dynamic_cli::error::ExecutionError::ContextDowncastFailed {
                 expected_type: "TaskRunnerContext".to_string(),
@@ -360,7 +347,7 @@ impl CommandHandler for CompleteCommand {
             })
         })?;
 
-        let id_str = args.get("id").ok_or_else(|| {
+        let id_str = args.get_scalar("id").ok_or_else(|| {
             DynamicCliError::Parse(dynamic_cli::error::ParseError::MissingArgument {
                 argument: "id".to_string(),
                 command: "complete".to_string(),
@@ -394,11 +381,7 @@ impl CommandHandler for CompleteCommand {
 struct DeleteCommand;
 
 impl CommandHandler for DeleteCommand {
-    fn execute(
-        &self,
-        context: &mut dyn ExecutionContext,
-        args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, context: &mut dyn ExecutionContext, args: &ParsedArgs) -> Result<()> {
         let ctx = downcast_mut::<TaskRunnerContext>(context).ok_or_else(|| {
             DynamicCliError::Execution(dynamic_cli::error::ExecutionError::ContextDowncastFailed {
                 expected_type: "TaskRunnerContext".to_string(),
@@ -406,7 +389,7 @@ impl CommandHandler for DeleteCommand {
             })
         })?;
 
-        let id_str = args.get("id").ok_or_else(|| {
+        let id_str = args.get_scalar("id").ok_or_else(|| {
             DynamicCliError::Parse(dynamic_cli::error::ParseError::MissingArgument {
                 argument: "id".to_string(),
                 command: "delete".to_string(),
@@ -427,11 +410,7 @@ impl CommandHandler for DeleteCommand {
 struct ClearCommand;
 
 impl CommandHandler for ClearCommand {
-    fn execute(
-        &self,
-        context: &mut dyn ExecutionContext,
-        _args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
         let ctx = downcast_mut::<TaskRunnerContext>(context).ok_or_else(|| {
             DynamicCliError::Execution(dynamic_cli::error::ExecutionError::ContextDowncastFailed {
                 expected_type: "TaskRunnerContext".to_string(),
@@ -455,11 +434,7 @@ impl CommandHandler for ClearCommand {
 struct StatsCommand;
 
 impl CommandHandler for StatsCommand {
-    fn execute(
-        &self,
-        context: &mut dyn ExecutionContext,
-        _args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
         let ctx = downcast_mut::<TaskRunnerContext>(context).ok_or_else(|| {
             DynamicCliError::Execution(dynamic_cli::error::ExecutionError::ContextDowncastFailed {
                 expected_type: "TaskRunnerContext".to_string(),

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -7,7 +7,6 @@
 //!
 //! ```no_run
 //! use dynamic_cli::prelude::*;
-//! use std::collections::HashMap;
 //!
 //! // Define context
 //! #[derive(Default)]
@@ -25,7 +24,7 @@
 //!     fn execute(
 //!         &self,
 //!         _context: &mut dyn ExecutionContext,
-//!         args: &HashMap<String, String>,
+//!         args: &ParsedArgs,
 //!     ) -> dynamic_cli::Result<()> {
 //!         println!("Hello!");
 //!         Ok(())
@@ -80,7 +79,7 @@ use std::path::PathBuf;
 /// # }
 /// # struct MyHandler;
 /// # impl CommandHandler for MyHandler {
-/// #     fn execute(&self, _: &mut dyn ExecutionContext, _: &std::collections::HashMap<String, String>) -> dynamic_cli::Result<()> { Ok(()) }
+/// #     fn execute(&self, _: &mut dyn ExecutionContext, _: &dynamic_cli::parser::ParsedArgs) -> dynamic_cli::Result<()> { Ok(()) }
 /// # }
 /// # fn main() -> dynamic_cli::Result<()> {
 /// let app = CliBuilder::new()
@@ -241,7 +240,6 @@ impl CliBuilder {
     ///
     /// ```
     /// use dynamic_cli::prelude::*;
-    /// use std::collections::HashMap;
     ///
     /// struct MyCommand;
     ///
@@ -249,7 +247,7 @@ impl CliBuilder {
     ///     fn execute(
     ///         &self,
     ///         _ctx: &mut dyn ExecutionContext,
-    ///         _args: &HashMap<String, String>,
+    ///         _args: &ParsedArgs,
     ///     ) -> dynamic_cli::Result<()> {
     ///         println!("Executed!");
     ///         Ok(())
@@ -303,7 +301,6 @@ impl CliBuilder {
     /// ```
     /// use dynamic_cli::prelude::*;
     /// use dynamic_cli::executor::AsyncCommandHandler;
-    /// use std::collections::HashMap;
     /// use async_trait::async_trait;
     ///
     /// struct FetchCommand;
@@ -313,7 +310,7 @@ impl CliBuilder {
     ///     async fn execute(
     ///         &self,
     ///         _ctx: &mut dyn ExecutionContext,
-    ///         _args: &HashMap<String, String>,
+    ///         _args: &ParsedArgs,
     ///     ) -> dynamic_cli::Result<()> {
     ///         println!("Fetched!");
     ///         Ok(())
@@ -505,7 +502,7 @@ impl CliBuilder {
     /// # }
     /// # struct MyHandler;
     /// # impl CommandHandler for MyHandler {
-    /// #     fn execute(&self, _: &mut dyn ExecutionContext, _: &std::collections::HashMap<String, String>) -> dynamic_cli::Result<()> { Ok(()) }
+    /// #     fn execute(&self, _: &mut dyn ExecutionContext, _: &dynamic_cli::parser::ParsedArgs) -> dynamic_cli::Result<()> { Ok(()) }
     /// # }
     /// # fn main() -> dynamic_cli::Result<()> {
     /// let app = CliBuilder::new()
@@ -662,7 +659,7 @@ impl Default for CliBuilder {
 /// # }
 /// # struct MyHandler;
 /// # impl CommandHandler for MyHandler {
-/// #     fn execute(&self, _: &mut dyn ExecutionContext, _: &std::collections::HashMap<String, String>) -> dynamic_cli::Result<()> { Ok(()) }
+/// #     fn execute(&self, _: &mut dyn ExecutionContext, _: &dynamic_cli::parser::ParsedArgs) -> dynamic_cli::Result<()> { Ok(()) }
 /// # }
 /// # fn main() -> dynamic_cli::Result<()> {
 /// let app = CliBuilder::new()
@@ -729,7 +726,7 @@ impl CliApp {
     /// # }
     /// # struct MyHandler;
     /// # impl CommandHandler for MyHandler {
-    /// #     fn execute(&self, _: &mut dyn ExecutionContext, _: &std::collections::HashMap<String, String>) -> dynamic_cli::Result<()> { Ok(()) }
+    /// #     fn execute(&self, _: &mut dyn ExecutionContext, _: &dynamic_cli::parser::ParsedArgs) -> dynamic_cli::Result<()> { Ok(()) }
     /// # }
     /// # fn main() -> dynamic_cli::Result<()> {
     /// # let app = CliBuilder::new()
@@ -787,7 +784,7 @@ impl CliApp {
     /// # }
     /// # struct MyHandler;
     /// # impl CommandHandler for MyHandler {
-    /// #     fn execute(&self, _: &mut dyn ExecutionContext, _: &std::collections::HashMap<String, String>) -> dynamic_cli::Result<()> { Ok(()) }
+    /// #     fn execute(&self, _: &mut dyn ExecutionContext, _: &dynamic_cli::parser::ParsedArgs) -> dynamic_cli::Result<()> { Ok(()) }
     /// # }
     /// # fn main() -> dynamic_cli::Result<()> {
     /// # let app = CliBuilder::new()
@@ -835,7 +832,7 @@ impl CliApp {
     /// # }
     /// # struct MyHandler;
     /// # impl CommandHandler for MyHandler {
-    /// #     fn execute(&self, _: &mut dyn ExecutionContext, _: &std::collections::HashMap<String, String>) -> dynamic_cli::Result<()> { Ok(()) }
+    /// #     fn execute(&self, _: &mut dyn ExecutionContext, _: &dynamic_cli::parser::ParsedArgs) -> dynamic_cli::Result<()> { Ok(()) }
     /// # }
     /// # fn main() -> dynamic_cli::Result<()> {
     /// # let app = CliBuilder::new()
@@ -863,7 +860,8 @@ impl CliApp {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::schema::{ArgumentDefinition, ArgumentType, CommandDefinition, Metadata};
+    use crate::config::schema::{CommandDefinition, Metadata};
+    use crate::parser::ParsedArgs;
 
     // Test context
     #[derive(Default)]
@@ -887,11 +885,7 @@ mod tests {
     }
 
     impl CommandHandler for TestHandler {
-        fn execute(
-            &self,
-            context: &mut dyn ExecutionContext,
-            _args: &HashMap<String, String>,
-        ) -> Result<()> {
+        fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
             let ctx =
                 crate::context::downcast_mut::<TestContext>(context).expect("Failed to downcast");
             ctx.executed.push(self.name.clone());
@@ -908,7 +902,7 @@ mod tests {
         async fn execute(
             &self,
             context: &mut dyn ExecutionContext,
-            _args: &HashMap<String, String>,
+            _args: &ParsedArgs,
         ) -> Result<()> {
             let ctx =
                 crate::context::downcast_mut::<TestContext>(context).expect("Failed to downcast");

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -11,6 +11,7 @@
 //! - [`ValidationRule`]: Validation constraints
 
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// Complete configuration for CLI/REPL commands
 ///
@@ -230,9 +231,33 @@ pub struct OptionDefinition {
 
     /// Restricted set of allowed values
     ///
-    /// If non-empty, the value must be one of these choices.
+    /// If non-empty, the value must be one of these choices. When
+    /// `repeatable` is `true`, this list also doubles as the set of
+    /// valid discriminants for each occurrence (see [`Self::option_parameters`]).
     #[serde(default)]
     pub choices: Vec<String>,
+
+    /// Whether this option can appear more than once on a single
+    /// command line, each occurrence carrying its own discriminant
+    /// (from `choices`) and `key=value` sub-parameters.
+    ///
+    /// Defaults to `false` — fully backward-compatible with existing
+    /// scalar options.
+    #[serde(default)]
+    pub repeatable: bool,
+
+    /// Per-discriminant shape of the `key=value` sub-parameters accepted
+    /// by a repeatable option.
+    ///
+    /// Keys must exactly match the entries in [`Self::choices`] (enforced
+    /// by the config validator, not at deserialization time). Each value
+    /// reuses [`ArgumentDefinition`] — the same vocabulary already used
+    /// for positional `arguments:` — rather than a dedicated mini-schema
+    /// type.
+    ///
+    /// Ignored (and should be empty) when `repeatable` is `false`.
+    #[serde(default)]
+    pub option_parameters: HashMap<String, Vec<ArgumentDefinition>>,
 }
 
 /// Supported argument and option types

--- a/src/config/validator.rs
+++ b/src/config/validator.rs
@@ -379,6 +379,112 @@ fn validate_options(options: &[OptionDefinition], context: &str) -> Result<()> {
             .into());
         }
 
+        // --- DD-024: repeatable options and their option_parameters shapes ---
+        if opt.repeatable {
+            // Rule: a repeatable option's absence already means zero
+            // occurrences, so a default value would be ambiguous — reject
+            // it before the generic default/choices check below, so the
+            // repeatable-specific message takes priority.
+            if let Some(ref default) = opt.default {
+                return Err(ConfigError::Inconsistency {
+                    details: format!(
+                        "Repeatable option '{}' cannot have a default value ('{}')",
+                        opt.name, default
+                    ),
+                    suggestion: Some(
+                        "Remove `default` — a repeatable option's absence already \
+                         means zero occurrences, not an implicit one."
+                            .to_string(),
+                    ),
+                }
+                .into());
+            }
+
+            // Rule: choices doubles as the discriminant list, so it must
+            // be non-empty for a repeatable option.
+            if opt.choices.is_empty() {
+                return Err(ConfigError::InvalidSchema {
+                    reason: format!(
+                        "Repeatable option '{}' must declare at least one discriminant in choices",
+                        opt.name
+                    ),
+                    path: Some(format!("{}.options[{}].choices", context, idx)),
+                    suggestion: Some(
+                        "Add `choices: [...]` listing the valid discriminants for \
+                         this repeatable option."
+                            .to_string(),
+                    ),
+                }
+                .into());
+            }
+
+            // Rule: option_parameters keys must equal choices exactly —
+            // no discriminant left undeclared, no orphan key.
+            for discriminant in &opt.choices {
+                if !opt.option_parameters.contains_key(discriminant) {
+                    return Err(ConfigError::InvalidSchema {
+                        reason: format!(
+                            "Discriminant '{}' is declared in choices for repeatable \
+                             option '{}' but has no matching entry in option_parameters",
+                            discriminant, opt.name
+                        ),
+                        path: Some(format!("{}.options[{}].option_parameters", context, idx)),
+                        suggestion: Some(format!(
+                            "Add an `option_parameters.{}` entry describing this \
+                             discriminant's key=value parameters.",
+                            discriminant
+                        )),
+                    }
+                    .into());
+                }
+            }
+            let choices_set: HashSet<&String> = opt.choices.iter().collect();
+            for key in opt.option_parameters.keys() {
+                if !choices_set.contains(key) {
+                    return Err(ConfigError::InvalidSchema {
+                        reason: format!(
+                            "option_parameters key '{}' on option '{}' is not declared in choices",
+                            key, opt.name
+                        ),
+                        path: Some(format!(
+                            "{}.options[{}].option_parameters.{}",
+                            context, idx, key
+                        )),
+                        suggestion: Some(format!(
+                            "Add '{}' to choices, or remove this option_parameters entry.",
+                            key
+                        )),
+                    }
+                    .into());
+                }
+            }
+
+            // Rule: each discriminant's key=value shape reuses the
+            // existing argument validation — names and types, but
+            // explicitly not ordering, which is meaningless for named
+            // key=value pairs rather than positional arguments.
+            for (discriminant, params) in &opt.option_parameters {
+                let sub_context = format!(
+                    "{}.options[{}].option_parameters.{}",
+                    context, idx, discriminant
+                );
+                validate_argument_names(params, &sub_context)?;
+                validate_argument_types(params)?;
+            }
+        } else if !opt.option_parameters.is_empty() {
+            // Rule: option_parameters is meaningless without repeatable.
+            return Err(ConfigError::Inconsistency {
+                details: format!(
+                    "Option '{}' has option_parameters but repeatable is false",
+                    opt.name
+                ),
+                suggestion: Some(
+                    "Set `repeatable: true`, or remove `option_parameters`.".to_string(),
+                ),
+            }
+            .into());
+        }
+
         // Validate choices are consistent with default
         if let Some(ref default) = opt.default {
             if !opt.choices.is_empty() && !opt.choices.contains(default) {
@@ -844,5 +950,246 @@ mod tests {
 
         let result = validate_options(&options, "test");
         assert!(result.is_err());
+    }
+
+    // ── DD-024: repeatable options / option_parameters ──────────────────────
+
+    #[test]
+    fn test_validate_repeatable_requires_non_empty_choices() {
+        let options = vec![OptionDefinition {
+            name: "output".to_string(),
+            short: None,
+            long: Some("output".to_string()),
+            option_type: ArgumentType::String,
+            required: false,
+            default: None,
+            description: "Output".to_string(),
+            choices: vec![], // Repeatable but no discriminants!
+            repeatable: true,
+            option_parameters: HashMap::new(),
+        }];
+
+        let result = validate_options(&options, "test");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_repeatable_missing_option_parameters_entry() {
+        let mut option_parameters = HashMap::new();
+        option_parameters.insert(
+            "csv".to_string(),
+            vec![ArgumentDefinition {
+                name: "file".to_string(),
+                arg_type: ArgumentType::Path,
+                required: true,
+                description: "Destination file".to_string(),
+                validation: vec![],
+                secure: false,
+            }],
+        );
+        // "plot" is in choices but has no option_parameters entry.
+        let options = vec![OptionDefinition {
+            name: "output".to_string(),
+            short: None,
+            long: Some("output".to_string()),
+            option_type: ArgumentType::String,
+            required: false,
+            default: None,
+            description: "Output".to_string(),
+            choices: vec!["csv".to_string(), "plot".to_string()],
+            repeatable: true,
+            option_parameters,
+        }];
+
+        let result = validate_options(&options, "test");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_repeatable_orphan_option_parameters_key() {
+        let mut option_parameters = HashMap::new();
+        option_parameters.insert(
+            "csv".to_string(),
+            vec![ArgumentDefinition {
+                name: "file".to_string(),
+                arg_type: ArgumentType::Path,
+                required: true,
+                description: "Destination file".to_string(),
+                validation: vec![],
+                secure: false,
+            }],
+        );
+        // "json" has an option_parameters entry but is not in choices.
+        option_parameters.insert(
+            "json".to_string(),
+            vec![ArgumentDefinition {
+                name: "file".to_string(),
+                arg_type: ArgumentType::Path,
+                required: true,
+                description: "Destination file".to_string(),
+                validation: vec![],
+                secure: false,
+            }],
+        );
+        let options = vec![OptionDefinition {
+            name: "output".to_string(),
+            short: None,
+            long: Some("output".to_string()),
+            option_type: ArgumentType::String,
+            required: false,
+            default: None,
+            description: "Output".to_string(),
+            choices: vec!["csv".to_string()],
+            repeatable: true,
+            option_parameters,
+        }];
+
+        let result = validate_options(&options, "test");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_repeatable_option_parameters_reuses_argument_validation() {
+        let mut option_parameters = HashMap::new();
+        option_parameters.insert(
+            "csv".to_string(),
+            vec![ArgumentDefinition {
+                name: "".to_string(), // Empty name — invalid per validate_argument_names.
+                arg_type: ArgumentType::Path,
+                required: true,
+                description: "Destination file".to_string(),
+                validation: vec![],
+                secure: false,
+            }],
+        );
+        let options = vec![OptionDefinition {
+            name: "output".to_string(),
+            short: None,
+            long: Some("output".to_string()),
+            option_type: ArgumentType::String,
+            required: false,
+            default: None,
+            description: "Output".to_string(),
+            choices: vec!["csv".to_string()],
+            repeatable: true,
+            option_parameters,
+        }];
+
+        let result = validate_options(&options, "test");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_non_repeatable_with_option_parameters_is_error() {
+        let mut option_parameters = HashMap::new();
+        option_parameters.insert(
+            "csv".to_string(),
+            vec![ArgumentDefinition {
+                name: "file".to_string(),
+                arg_type: ArgumentType::Path,
+                required: true,
+                description: "Destination file".to_string(),
+                validation: vec![],
+                secure: false,
+            }],
+        );
+        let options = vec![OptionDefinition {
+            name: "output".to_string(),
+            short: None,
+            long: Some("output".to_string()),
+            option_type: ArgumentType::String,
+            required: false,
+            default: None,
+            description: "Output".to_string(),
+            choices: vec!["csv".to_string()],
+            repeatable: false, // option_parameters set despite repeatable: false!
+            option_parameters,
+        }];
+
+        let result = validate_options(&options, "test");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_repeatable_with_default_is_error() {
+        let mut option_parameters = HashMap::new();
+        option_parameters.insert(
+            "csv".to_string(),
+            vec![ArgumentDefinition {
+                name: "file".to_string(),
+                arg_type: ArgumentType::Path,
+                required: true,
+                description: "Destination file".to_string(),
+                validation: vec![],
+                secure: false,
+            }],
+        );
+        let options = vec![OptionDefinition {
+            name: "output".to_string(),
+            short: None,
+            long: Some("output".to_string()),
+            option_type: ArgumentType::String,
+            required: false,
+            default: Some("csv".to_string()), // Forbidden when repeatable: true!
+            description: "Output".to_string(),
+            choices: vec!["csv".to_string()],
+            repeatable: true,
+            option_parameters,
+        }];
+
+        let result = validate_options(&options, "test");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_repeatable_valid_config_passes() {
+        let mut option_parameters = HashMap::new();
+        option_parameters.insert(
+            "csv".to_string(),
+            vec![
+                ArgumentDefinition {
+                    name: "file".to_string(),
+                    arg_type: ArgumentType::Path,
+                    required: true,
+                    description: "Destination CSV file".to_string(),
+                    validation: vec![],
+                    secure: false,
+                },
+                ArgumentDefinition {
+                    name: "resolution".to_string(),
+                    arg_type: ArgumentType::Integer,
+                    required: false,
+                    description: "Time-step resolution".to_string(),
+                    validation: vec![],
+                    secure: false,
+                },
+            ],
+        );
+        option_parameters.insert(
+            "plot".to_string(),
+            vec![ArgumentDefinition {
+                name: "file".to_string(),
+                arg_type: ArgumentType::Path,
+                required: true,
+                description: "Destination image file".to_string(),
+                validation: vec![],
+                secure: false,
+            }],
+        );
+        let options = vec![OptionDefinition {
+            name: "output".to_string(),
+            short: None,
+            long: Some("output".to_string()),
+            option_type: ArgumentType::String,
+            required: false,
+            default: None,
+            description: "Write simulation results in one or more output kinds".to_string(),
+            choices: vec!["csv".to_string(), "plot".to_string()],
+            repeatable: true,
+            option_parameters,
+        }];
+
+        let result = validate_options(&options, "test");
+        assert!(result.is_ok());
     }
 }

--- a/src/config/validator.rs
+++ b/src/config/validator.rs
@@ -495,6 +495,7 @@ fn check_name_conflicts(
 mod tests {
     use super::*;
     use crate::config::schema::CommandsConfig;
+    use std::collections::HashMap;
 
     #[test]
     fn test_validate_config_empty() {
@@ -681,6 +682,8 @@ mod tests {
             default: None,
             description: "Option".to_string(),
             choices: vec![],
+            repeatable: false,
+            option_parameters: HashMap::new(),
         }];
 
         let result = validate_options(&options, "test");
@@ -698,6 +701,8 @@ mod tests {
             default: Some("invalid".to_string()), // Not in choices!
             description: "Mode".to_string(),
             choices: vec!["fast".to_string(), "slow".to_string()],
+            repeatable: false,
+            option_parameters: HashMap::new(),
         }];
 
         let result = validate_options(&options, "test");
@@ -716,6 +721,8 @@ mod tests {
                 default: None,
                 description: "Option 1".to_string(),
                 choices: vec![],
+                repeatable: false,
+                option_parameters: HashMap::new(),
             },
             OptionDefinition {
                 name: "opt2".to_string(),
@@ -726,6 +733,8 @@ mod tests {
                 default: None,
                 description: "Option 2".to_string(),
                 choices: vec![],
+                repeatable: false,
+                option_parameters: HashMap::new(),
             },
         ];
 
@@ -744,6 +753,8 @@ mod tests {
             default: None,
             description: "Option".to_string(),
             choices: vec![],
+            repeatable: false,
+            option_parameters: HashMap::new(),
         }];
 
         let result = validate_option_flags(&options, "test");
@@ -770,6 +781,8 @@ mod tests {
             default: None,
             description: "Output".to_string(),
             choices: vec![],
+            repeatable: false,
+            option_parameters: HashMap::new(),
         }];
 
         let result = check_name_conflicts(&args, &options, "test");
@@ -805,6 +818,8 @@ mod tests {
                 default: Some("out.csv".to_string()),
                 description: "Output file".to_string(),
                 choices: vec![],
+                repeatable: false,
+                option_parameters: HashMap::new(),
             }],
             implementation: "process_handler".to_string(),
         };
@@ -823,6 +838,8 @@ mod tests {
             default: None,
             description: "A flag".to_string(),
             choices: vec!["true".to_string(), "false".to_string()], // Boolean can't have choices!
+            repeatable: false,
+            option_parameters: HashMap::new(),
         }];
 
         let result = validate_options(&options, "test");

--- a/src/context/traits.rs
+++ b/src/context/traits.rs
@@ -99,7 +99,7 @@ use std::any::Any;
 ///
 /// ```
 /// use dynamic_cli::context::{ExecutionContext, downcast_mut};
-/// use std::collections::HashMap;///
+/// use dynamic_cli::parser::ParsedArgs;
 /// #
 /// use rustyline::Context;
 ///
@@ -111,7 +111,7 @@ use std::any::Any;
 /// #
 /// fn my_handler(
 ///     context: &mut dyn ExecutionContext,
-///     args: &HashMap<String, String>,
+///     args: &ParsedArgs,
 /// ) -> Result<(), Box<dyn std::error::Error>> {
 ///     // Downcast to concrete type
 ///     let ctx = downcast_mut::<MyContext>(context)

--- a/src/error/display.rs
+++ b/src/error/display.rs
@@ -203,7 +203,11 @@ fn format_parse_error(output: &mut String, error: &ParseError) {
 
         ParseError::MissingArgument { suggestion, .. }
         | ParseError::MissingOption { suggestion, .. }
-        | ParseError::TooManyArguments { suggestion, .. } => {
+        | ParseError::TooManyArguments { suggestion, .. }
+        | ParseError::UnknownOptionParameter { suggestion, .. }
+        | ParseError::MissingRequiredOptionParameter { suggestion, .. }
+        | ParseError::UnknownDiscriminant { suggestion, .. }
+        | ParseError::DuplicateOptionOccurrence { suggestion, .. } => {
             append_suggestion(output, suggestion.as_deref());
         }
 
@@ -515,6 +519,118 @@ mod tests {
         let formatted = format_error(&error);
         assert!(formatted.contains("run"));
         assert!(formatted.contains("Run --help run"));
+    }
+
+    // ── format_error — Parse (DD-024 repeatable options, #37) ───────────
+
+    #[test]
+    fn test_format_parse_unknown_option_parameter_with_suggestion() {
+        let error: DynamicCliError = ParseError::UnknownOptionParameter {
+            option: "output".to_string(),
+            discriminant: "csv".to_string(),
+            key: "compression".to_string(),
+            valid_keys: vec!["file".to_string(), "resolution".to_string()],
+            suggestion: Some("Run --help export to see valid keys for --output csv.".to_string()),
+        }
+        .into();
+
+        let formatted = format_error(&error);
+        assert!(formatted.contains("compression"));
+        assert!(formatted.contains("csv"));
+        assert!(formatted.contains("file"));
+        assert!(formatted.contains("resolution"));
+        assert!(formatted.contains("Run --help export"));
+    }
+
+    #[test]
+    fn test_format_parse_missing_required_option_parameter_with_suggestion() {
+        let error: DynamicCliError = ParseError::MissingRequiredOptionParameter {
+            option: "output".to_string(),
+            discriminant: "csv".to_string(),
+            key: "file".to_string(),
+            suggestion: Some(
+                "Run --help export to see required keys for --output csv.".to_string(),
+            ),
+        }
+        .into();
+
+        let formatted = format_error(&error);
+        assert!(formatted.contains("file"));
+        assert!(formatted.contains("csv"));
+        assert!(formatted.contains("Run --help export"));
+    }
+
+    #[test]
+    fn test_format_parse_unknown_discriminant_with_suggestion() {
+        let error: DynamicCliError = ParseError::UnknownDiscriminant {
+            option: "output".to_string(),
+            value: "xml".to_string(),
+            valid_choices: vec!["csv".to_string(), "plot".to_string()],
+            suggestion: Some("Run --help export to see valid --output kinds.".to_string()),
+        }
+        .into();
+
+        let formatted = format_error(&error);
+        assert!(formatted.contains("xml"));
+        assert!(formatted.contains("csv"));
+        assert!(formatted.contains("plot"));
+        assert!(formatted.contains("Run --help export"));
+    }
+
+    #[test]
+    fn test_format_parse_duplicate_option_occurrence_with_suggestion() {
+        let error: DynamicCliError = ParseError::DuplicateOptionOccurrence {
+            option: "output".to_string(),
+            discriminant: "csv".to_string(),
+            params: vec![("file".to_string(), "results.csv".to_string())],
+            suggestion: Some(
+                "Remove one of the two identical --output csv occurrences.".to_string(),
+            ),
+        }
+        .into();
+
+        let formatted = format_error(&error);
+        assert!(formatted.contains("results.csv"));
+        assert!(formatted.contains("csv"));
+        assert!(formatted.contains("Remove one of the two identical"));
+    }
+
+    #[test]
+    fn test_debug_new_parse_error_variants_dd024() {
+        // Debug is derived; a smoke test is enough to guard against a
+        // silent #[derive(Debug)] removal on ParseError.
+        let variants: Vec<ParseError> = vec![
+            ParseError::UnknownOptionParameter {
+                option: "output".to_string(),
+                discriminant: "csv".to_string(),
+                key: "compression".to_string(),
+                valid_keys: vec!["file".to_string()],
+                suggestion: None,
+            },
+            ParseError::MissingRequiredOptionParameter {
+                option: "output".to_string(),
+                discriminant: "csv".to_string(),
+                key: "file".to_string(),
+                suggestion: None,
+            },
+            ParseError::UnknownDiscriminant {
+                option: "output".to_string(),
+                value: "xml".to_string(),
+                valid_choices: vec!["csv".to_string()],
+                suggestion: None,
+            },
+            ParseError::DuplicateOptionOccurrence {
+                option: "output".to_string(),
+                discriminant: "csv".to_string(),
+                params: vec![("file".to_string(), "results.csv".to_string())],
+                suggestion: None,
+            },
+        ];
+
+        for variant in variants {
+            let debug_str = format!("{:?}", variant);
+            assert!(!debug_str.is_empty());
+        }
     }
 
     #[test]

--- a/src/error/types.rs
+++ b/src/error/types.rs
@@ -225,7 +225,13 @@ pub enum ConfigError {
 ///
 /// These errors occur when analyzing arguments provided
 /// by the user in CLI or REPL mode.
+///
+/// Marked `#[non_exhaustive]` (DD-024, #37): repeatable-option parsing
+/// added four variants in one release, and more argument-shape features
+/// are expected before v1.0.0. External `match` expressions must include
+/// a wildcard arm.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ParseError {
     /// Unknown command
     ///
@@ -350,6 +356,125 @@ pub enum ParseError {
         details: String,
         /// Example of correct syntax
         hint: Option<String>,
+    },
+
+    /// Unknown key inside a repeatable option's occurrence
+    ///
+    /// The discriminant itself was valid, but a `key=value` pair used a
+    /// key not declared in that discriminant's `option_parameters`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use dynamic_cli::error::ParseError;
+    ///
+    /// let error = ParseError::UnknownOptionParameter {
+    ///     option: "output".to_string(),
+    ///     discriminant: "csv".to_string(),
+    ///     key: "compression".to_string(),
+    ///     valid_keys: vec!["file".to_string(), "resolution".to_string()],
+    ///     suggestion: Some("Run --help export to see valid keys for --output csv.".to_string()),
+    /// };
+    /// let msg = format!("{}", error);
+    /// assert!(msg.contains("compression"));
+    /// ```
+    #[error("Unknown parameter '{key}' for option --{option} (discriminant '{discriminant}'). Valid keys: {}", 
+        .valid_keys.join(", "))]
+    UnknownOptionParameter {
+        option: String,
+        discriminant: String,
+        key: String,
+        valid_keys: Vec<String>,
+        /// Actionable hint surfaced to the user (not part of the Display string)
+        suggestion: Option<String>,
+    },
+
+    /// Required key missing from a repeatable option's occurrence
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use dynamic_cli::error::ParseError;
+    ///
+    /// let error = ParseError::MissingRequiredOptionParameter {
+    ///     option: "output".to_string(),
+    ///     discriminant: "csv".to_string(),
+    ///     key: "file".to_string(),
+    ///     suggestion: Some("Run --help export to see required keys for --output csv.".to_string()),
+    /// };
+    /// let msg = format!("{}", error);
+    /// assert!(msg.contains("file"));
+    /// ```
+    #[error(
+        "Missing required parameter '{key}' for option --{option} (discriminant '{discriminant}')"
+    )]
+    MissingRequiredOptionParameter {
+        option: String,
+        discriminant: String,
+        key: String,
+        /// Actionable hint surfaced to the user (not part of the Display string)
+        suggestion: Option<String>,
+    },
+
+    /// Unknown discriminant for a repeatable option
+    ///
+    /// The token immediately after a repeatable option's flag did not
+    /// match any entry in that option's `choices`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use dynamic_cli::error::ParseError;
+    ///
+    /// let error = ParseError::UnknownDiscriminant {
+    ///     option: "output".to_string(),
+    ///     value: "xml".to_string(),
+    ///     valid_choices: vec!["csv".to_string(), "plot".to_string()],
+    ///     suggestion: Some("Run --help export to see valid --output kinds.".to_string()),
+    /// };
+    /// let msg = format!("{}", error);
+    /// assert!(msg.contains("xml"));
+    /// ```
+    #[error("Unknown discriminant '{value}' for option --{option}. Valid choices: {}", 
+        .valid_choices.join(", "))]
+    UnknownDiscriminant {
+        option: String,
+        value: String,
+        valid_choices: Vec<String>,
+        /// Actionable hint surfaced to the user (not part of the Display string)
+        suggestion: Option<String>,
+    },
+
+    /// The same repeatable-option occurrence was supplied twice
+    ///
+    /// Raised only when two occurrences share both the same discriminant
+    /// and exactly the same `key=value` pairs — a pure equality check the
+    /// framework can make without domain knowledge. Partially-overlapping
+    /// occurrences (same discriminant, different values) are *not*
+    /// rejected here; that stays the handler's responsibility (DD-024).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use dynamic_cli::error::ParseError;
+    ///
+    /// let error = ParseError::DuplicateOptionOccurrence {
+    ///     option: "output".to_string(),
+    ///     discriminant: "csv".to_string(),
+    ///     params: vec![("file".to_string(), "results.csv".to_string())],
+    ///     suggestion: Some("Remove one of the two identical --output csv occurrences.".to_string()),
+    /// };
+    /// let msg = format!("{}", error);
+    /// assert!(msg.contains("results.csv"));
+    /// ```
+    #[error("Duplicate occurrence of --{option} {discriminant} with identical parameters: {}", 
+        .params.iter().map(|(k, v)| format!("{}={}", k, v)).collect::<Vec<_>>().join(", "))]
+    DuplicateOptionOccurrence {
+        option: String,
+        discriminant: String,
+        params: Vec<(String, String)>,
+        /// Actionable hint surfaced to the user (not part of the Display string)
+        suggestion: Option<String>,
     },
 }
 

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -44,18 +44,18 @@
 //! ## Simplicity
 //!
 //! The API is intentionally kept simple:
-//! - Arguments are passed as `HashMap<String, String>`
+//! - Arguments are passed as [`crate::parser::ParsedArgs`]
 //! - Context is accessed through trait objects
 //! - Error handling uses the framework's standard `Result` type
 //!
 //! # Quick Start
 //!
 //! ```
-//! use std::collections::HashMap;
 //! use dynamic_cli::error::ExecutionError;
-//! use dynamic_cli::executor::CommandHandler;
+//! use dynamic_cli::executor::{CommandHandler, ParsedArgs};
 //! use dynamic_cli::context::ExecutionContext;
 //! use dynamic_cli::Result;
+//! use std::collections::HashMap;
 //!
 //! // 1. Define your context
 //! #[derive(Default)]
@@ -75,12 +75,12 @@
 //!     fn execute(
 //!         &self,
 //!         context: &mut dyn ExecutionContext,
-//!         args: &HashMap<String, String>,
+//!         args: &ParsedArgs,
 //!     ) -> Result<()> {
 //!         let ctx = dynamic_cli::context::downcast_mut::<AppContext>(context)
 //!             .ok_or_else(|| ExecutionError::CommandFailed(anyhow::anyhow!("Wrong context type")))?;
 //!         
-//!         let amount: i32 = args.get("amount")
+//!         let amount: i32 = args.get_scalar("amount")
 //!             .and_then(|s| s.parse().ok())
 //!             .unwrap_or(1);
 //!         
@@ -94,8 +94,9 @@
 //! # fn main() -> Result<()> {
 //! let handler = IncrementCommand;
 //! let mut context = AppContext::default();
-//! let mut args = HashMap::new();
-//! args.insert("amount".to_string(), "5".to_string());
+//! let mut raw_args = HashMap::new();
+//! raw_args.insert("amount".to_string(), "5".to_string());
+//! let args = ParsedArgs::from_scalars(raw_args);
 //!
 //! handler.execute(&mut context, &args)?;
 //! assert_eq!(context.counter, 5);
@@ -108,8 +109,7 @@
 //! ## Basic Command
 //!
 //! ```
-//! use std::collections::HashMap;
-//! use dynamic_cli::executor::CommandHandler;
+//! use dynamic_cli::executor::{CommandHandler, ParsedArgs};
 //! use dynamic_cli::context::ExecutionContext;
 //! use dynamic_cli::Result;
 //!
@@ -119,9 +119,9 @@
 //!     fn execute(
 //!         &self,
 //!         _context: &mut dyn ExecutionContext,
-//!         args: &HashMap<String, String>,
+//!         args: &ParsedArgs,
 //!     ) -> Result<()> {
-//!         if let Some(message) = args.get("message") {
+//!         if let Some(message) = args.get_scalar("message") {
 //!             println!("{}", message);
 //!         }
 //!         Ok(())
@@ -132,9 +132,8 @@
 //! ## Command with Validation
 //!
 //! ```
-//! use std::collections::HashMap;
 //! use dynamic_cli::error::ExecutionError;
-//! use dynamic_cli::executor::CommandHandler;
+//! use dynamic_cli::executor::{CommandHandler, ParsedArgs};
 //! use dynamic_cli::context::ExecutionContext;
 //! use dynamic_cli::DynamicCliError::Execution;
 //! use dynamic_cli::Result;
@@ -145,9 +144,9 @@
 //!     fn execute(
 //!         &self,
 //!         _context: &mut dyn ExecutionContext,
-//!         args: &HashMap<String, String>,
+//!         args: &ParsedArgs,
 //!     ) -> dynamic_cli::Result<()> {
-//!         let denom = args.get("denominator")
+//!         let denom = args.get_scalar("denominator")
 //!             .ok_or_else(|| {
 //!                 ExecutionError::CommandFailed(
 //!                     anyhow::anyhow!("Missing Denominator"))})?;
@@ -169,9 +168,8 @@
 //! ## Stateful Command
 //!
 //! ```
-//! use std::collections::HashMap;
 //! use dynamic_cli::error::ExecutionError;
-//! use dynamic_cli::executor::CommandHandler;
+//! use dynamic_cli::executor::{CommandHandler, ParsedArgs};
 //! use dynamic_cli::context::ExecutionContext;
 //! use dynamic_cli::Result;
 //!
@@ -191,15 +189,15 @@
 //!     fn execute(
 //!         &self,
 //!         context: &mut dyn ExecutionContext,
-//!         args: &HashMap<String, String>,
+//!         args: &ParsedArgs,
 //!     ) -> Result<()> {
 //!         let ctx = dynamic_cli::context::downcast_mut::<FileContext>(context)
 //!             .ok_or_else(|| ExecutionError::CommandFailed(anyhow::anyhow!("Wrong context type")))?;
 //!         
-//!         let filename = args.get("file")
+//!         let filename = args.get_scalar("file")
 //!             .ok_or_else(|| { ExecutionError::CommandFailed(anyhow::anyhow!("Missing file argument"))})?;
 //!         
-//!         ctx.current_file = Some(filename.clone());
+//!         ctx.current_file = Some(filename.to_string());
 //!         println!("Opened: {}", filename);
 //!         Ok(())
 //!     }
@@ -243,8 +241,7 @@
 //! ## Error Handling Pattern
 //!
 //! ```
-//! use std::collections::HashMap;
-//! use dynamic_cli::executor::CommandHandler;
+//! use dynamic_cli::executor::{CommandHandler, ParsedArgs};
 //! use dynamic_cli::context::ExecutionContext;
 //! use dynamic_cli::error::ExecutionError;
 //! use dynamic_cli::Result;
@@ -255,9 +252,9 @@
 //!     fn execute(
 //!         &self,
 //!         _context: &mut dyn ExecutionContext,
-//!         args: &HashMap<String, String>,
+//!         args: &ParsedArgs,
 //!     ) -> Result<()> {
-//!         let path = args.get("path")
+//!         let path = args.get_scalar("path")
 //!             .ok_or_else(|| { ExecutionError::CommandFailed(anyhow::anyhow!("Missing path argument"))})?;
 //!         
 //!         // Wrap application errors in ExecutionError
@@ -275,6 +272,7 @@
 pub mod traits;
 
 // Public re-exports for convenience
+pub use crate::parser::ParsedArgs;
 pub use traits::{AsyncCommandHandler, CommandHandler};
 
 #[cfg(test)]
@@ -313,17 +311,14 @@ mod tests {
         fn execute(
             &self,
             context: &mut dyn ExecutionContext,
-            args: &HashMap<String, String>,
+            args: &ParsedArgs,
         ) -> crate::error::Result<()> {
             let ctx =
                 crate::context::downcast_mut::<IntegrationContext>(context).ok_or_else(|| {
                     ExecutionError::CommandFailed(anyhow::anyhow!("Wrong context type"))
                 })?;
 
-            let message = args
-                .get("message")
-                .map(|s| s.as_str())
-                .unwrap_or("default message");
+            let message = args.get_scalar("message").unwrap_or("default message");
             ctx.log.push(message.to_string());
             Ok(())
         }
@@ -336,15 +331,15 @@ mod tests {
         fn execute(
             &self,
             context: &mut dyn ExecutionContext,
-            args: &HashMap<String, String>,
+            args: &ParsedArgs,
         ) -> crate::error::Result<()> {
             let ctx =
                 crate::context::downcast_mut::<IntegrationContext>(context).ok_or_else(|| {
                     ExecutionError::CommandFailed(anyhow::anyhow!("Wrong context type"))
                 })?;
 
-            if let (Some(key), Some(value)) = (args.get("key"), args.get("value")) {
-                ctx.state.insert(key.clone(), value.clone());
+            if let (Some(key), Some(value)) = (args.get_scalar("key"), args.get_scalar("value")) {
+                ctx.state.insert(key.to_string(), value.to_string());
             }
             Ok(())
         }
@@ -357,14 +352,14 @@ mod tests {
         fn execute(
             &self,
             context: &mut dyn ExecutionContext,
-            args: &HashMap<String, String>,
+            args: &ParsedArgs,
         ) -> crate::error::Result<()> {
             let ctx =
                 crate::context::downcast_mut::<IntegrationContext>(context).ok_or_else(|| {
                     ExecutionError::CommandFailed(anyhow::anyhow!("Wrong context type"))
                 })?;
 
-            if let Some(key) = args.get("key") {
+            if let Some(key) = args.get_scalar("key") {
                 if let Some(value) = ctx.state.get(key) {
                     ctx.log.push(format!("{} = {}", key, value));
                 } else {
@@ -397,11 +392,13 @@ mod tests {
         let log_cmd = LogCommand;
         let mut args1 = HashMap::new();
         args1.insert("message".to_string(), "First".to_string());
+        let args1 = ParsedArgs::from_scalars(args1);
         log_cmd.execute(&mut context, &args1).unwrap();
 
         // Execute second command
         let mut args2 = HashMap::new();
         args2.insert("message".to_string(), "Second".to_string());
+        let args2 = ParsedArgs::from_scalars(args2);
         log_cmd.execute(&mut context, &args2).unwrap();
 
         // Verify both commands executed
@@ -420,21 +417,25 @@ mod tests {
         let mut args1 = HashMap::new();
         args1.insert("key".to_string(), "name".to_string());
         args1.insert("value".to_string(), "Alice".to_string());
+        let args1 = ParsedArgs::from_scalars(args1);
         set_cmd.execute(&mut context, &args1).unwrap();
 
         let mut args2 = HashMap::new();
         args2.insert("key".to_string(), "age".to_string());
         args2.insert("value".to_string(), "30".to_string());
+        let args2 = ParsedArgs::from_scalars(args2);
         set_cmd.execute(&mut context, &args2).unwrap();
 
         // Retrieve values
         let get_cmd = GetCommand;
         let mut args3 = HashMap::new();
         args3.insert("key".to_string(), "name".to_string());
+        let args3 = ParsedArgs::from_scalars(args3);
         get_cmd.execute(&mut context, &args3).unwrap();
 
         let mut args4 = HashMap::new();
         args4.insert("key".to_string(), "age".to_string());
+        let args4 = ParsedArgs::from_scalars(args4);
         get_cmd.execute(&mut context, &args4).unwrap();
 
         // Verify workflow
@@ -463,15 +464,18 @@ mod tests {
 
         let mut args1 = HashMap::new();
         args1.insert("message".to_string(), "test".to_string());
+        let args1 = ParsedArgs::from_scalars(args1);
         handlers[0].execute(&mut context, &args1).unwrap();
 
         let mut args2 = HashMap::new();
         args2.insert("key".to_string(), "k".to_string());
         args2.insert("value".to_string(), "v".to_string());
+        let args2 = ParsedArgs::from_scalars(args2);
         handlers[1].execute(&mut context, &args2).unwrap();
 
         let mut args3 = HashMap::new();
         args3.insert("key".to_string(), "k".to_string());
+        let args3 = ParsedArgs::from_scalars(args3);
         handlers[2].execute(&mut context, &args3).unwrap();
 
         assert_eq!(context.log.len(), 2);
@@ -487,12 +491,14 @@ mod tests {
         let mut args = HashMap::new();
         args.insert("key".to_string(), "shared".to_string());
         args.insert("value".to_string(), "value".to_string());
+        let args = ParsedArgs::from_scalars(args);
         set_cmd.execute(&mut context, &args).unwrap();
 
         // Another command can see the state
         let get_cmd = GetCommand;
         let mut args2 = HashMap::new();
         args2.insert("key".to_string(), "shared".to_string());
+        let args2 = ParsedArgs::from_scalars(args2);
         get_cmd.execute(&mut context, &args2).unwrap();
 
         assert!(context.log[0].contains("shared = value"));
@@ -507,7 +513,7 @@ mod tests {
             fn execute(
                 &self,
                 _context: &mut dyn ExecutionContext,
-                _args: &HashMap<String, String>,
+                _args: &ParsedArgs,
             ) -> crate::error::Result<()> {
                 Err(ExecutionError::CommandFailed(anyhow::anyhow!("Intentional failure")).into())
             }
@@ -516,6 +522,7 @@ mod tests {
         let handler = FailingCommand;
         let mut context = IntegrationContext::default();
         let args = HashMap::new();
+        let args = ParsedArgs::from_scalars(args);
 
         let result = handler.execute(&mut context, &args);
 
@@ -533,7 +540,7 @@ mod tests {
             fn execute(
                 &self,
                 context: &mut dyn ExecutionContext,
-                _args: &HashMap<String, String>,
+                _args: &ParsedArgs,
             ) -> crate::error::Result<()> {
                 let ctx = crate::context::downcast_mut::<IntegrationContext>(context).ok_or_else(
                     || ExecutionError::CommandFailed(anyhow::anyhow!("Wrong context type")),
@@ -542,8 +549,8 @@ mod tests {
                 Ok(())
             }
 
-            fn validate(&self, args: &HashMap<String, String>) -> crate::error::Result<()> {
-                if !args.contains_key("required") {
+            fn validate(&self, args: &ParsedArgs) -> crate::error::Result<()> {
+                if args.get_scalar("required").is_none() {
                     return Err(ExecutionError::CommandFailed(anyhow::anyhow!(
                         "Missing required argument"
                     ))
@@ -558,12 +565,14 @@ mod tests {
 
         // Test validation failure
         let args_invalid = HashMap::new();
+        let args_invalid = ParsedArgs::from_scalars(args_invalid);
         assert!(handler.validate(&args_invalid).is_err());
         assert!(handler.execute(&mut context, &args_invalid).is_ok()); // Execute would work
 
         // Test validation success
         let mut args_valid = HashMap::new();
         args_valid.insert("required".to_string(), "value".to_string());
+        let args_valid = ParsedArgs::from_scalars(args_valid);
         assert!(handler.validate(&args_valid).is_ok());
         assert!(handler.execute(&mut context, &args_valid).is_ok());
     }
@@ -591,13 +600,16 @@ mod tests {
             fn execute(
                 &self,
                 context: &mut dyn ExecutionContext,
-                args: &HashMap<String, String>,
+                args: &ParsedArgs,
             ) -> crate::error::Result<()> {
                 let ctx = crate::context::downcast_mut::<AppContext>(context).ok_or_else(|| {
                     ExecutionError::CommandFailed(anyhow::anyhow!("Wrong context type"))
                 })?;
 
-                let amount: i32 = args.get("amount").and_then(|s| s.parse().ok()).unwrap_or(1);
+                let amount: i32 = args
+                    .get_scalar("amount")
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(1);
 
                 ctx.counter += amount;
                 Ok(())
@@ -608,6 +620,7 @@ mod tests {
         let mut context = AppContext::default();
         let mut args = HashMap::new();
         args.insert("amount".to_string(), "5".to_string());
+        let args = ParsedArgs::from_scalars(args);
 
         handler.execute(&mut context, &args).unwrap();
         assert_eq!(context.counter, 5);
@@ -623,24 +636,28 @@ mod tests {
         let mut args1 = HashMap::new();
         args1.insert("key".to_string(), "initialized".to_string());
         args1.insert("value".to_string(), "true".to_string());
+        let args1 = ParsedArgs::from_scalars(args1);
         set_cmd.execute(&mut context, &args1).unwrap();
 
         // Step 2: Log the initialization
         let log_cmd = LogCommand;
         let mut args2 = HashMap::new();
         args2.insert("message".to_string(), "System initialized".to_string());
+        let args2 = ParsedArgs::from_scalars(args2);
         log_cmd.execute(&mut context, &args2).unwrap();
 
         // Step 3: Set more state
         let mut args3 = HashMap::new();
         args3.insert("key".to_string(), "user".to_string());
         args3.insert("value".to_string(), "admin".to_string());
+        let args3 = ParsedArgs::from_scalars(args3);
         set_cmd.execute(&mut context, &args3).unwrap();
 
         // Step 4: Query state
         let get_cmd = GetCommand;
         let mut args4 = HashMap::new();
         args4.insert("key".to_string(), "user".to_string());
+        let args4 = ParsedArgs::from_scalars(args4);
         get_cmd.execute(&mut context, &args4).unwrap();
 
         // Verify the complete workflow

--- a/src/executor/traits.rs
+++ b/src/executor/traits.rs
@@ -18,10 +18,10 @@
 //!
 //! ## Simple Type Signatures
 //!
-//! Arguments are passed as `HashMap<String, String>` rather than generic types.
-//! This design choice:
+//! Arguments are passed as [`crate::parser::ParsedArgs`] rather than generic
+//! types. This design choice:
 //! - Maintains object safety
-//! - Provides flexibility in argument types
+//! - Represents both scalar and repeatable-option values (DD-024)
 //! - Delegates type parsing to the parser module
 //!
 //! ## Thread Safety
@@ -34,8 +34,7 @@
 //! # Example
 //!
 //! ```
-//! use std::collections::HashMap;
-//! use dynamic_cli::executor::CommandHandler;
+//! use dynamic_cli::executor::{CommandHandler, ParsedArgs};
 //! use dynamic_cli::context::ExecutionContext;
 //! use dynamic_cli::Result;
 //!
@@ -46,9 +45,9 @@
 //!     fn execute(
 //!         &self,
 //!         _context: &mut dyn ExecutionContext,
-//!         args: &HashMap<String, String>,
+//!         args: &ParsedArgs,
 //!     ) -> Result<()> {
-//!         let name = args.get("name").map(|s| s.as_str()).unwrap_or("World");
+//!         let name = args.get_scalar("name").unwrap_or("World");
 //!         println!("Hello, {}!", name);
 //!         Ok(())
 //!     }
@@ -57,8 +56,8 @@
 
 use crate::context::ExecutionContext;
 use crate::error::Result;
+use crate::parser::ParsedArgs;
 use async_trait::async_trait;
-use std::collections::HashMap;
 
 /// Trait for command implementations
 ///
@@ -81,7 +80,7 @@ use std::collections::HashMap;
 ///
 /// # Execution Flow
 ///
-/// 1. Parser converts user input to `HashMap<String, String>`
+/// 1. Parser converts user input to [`crate::parser::ParsedArgs`]
 /// 2. Validator checks argument constraints
 /// 3. `validate()` is called for custom validation (optional)
 /// 4. `execute()` is called with validated arguments
@@ -89,9 +88,8 @@ use std::collections::HashMap;
 /// # Example
 ///
 /// ```
-/// use std::collections::HashMap;
 /// use dynamic_cli::error::ExecutionError;
-/// use dynamic_cli::executor::CommandHandler;
+/// use dynamic_cli::executor::{CommandHandler, ParsedArgs};
 /// use dynamic_cli::context::ExecutionContext;
 /// use dynamic_cli::Result;
 ///
@@ -101,16 +99,16 @@ use std::collections::HashMap;
 ///     fn execute(
 ///         &self,
 ///         _context: &mut dyn ExecutionContext,
-///         args: &HashMap<String, String>,
+///         args: &ParsedArgs,
 ///     ) -> Result<()> {
-///         let name = args.get("name")
+///         let name = args.get_scalar("name")
 ///             .ok_or_else(|| {
 ///                 ExecutionError::CommandFailed(
 ///                     anyhow::anyhow!("Missing 'name' argument")
 ///              )
 ///          })?;
 ///         
-///         let greeting = if let Some(formal) = args.get("formal") {
+///         let greeting = if let Some(formal) = args.get_scalar("formal") {
 ///             if formal == "true" {
 ///                 format!("Good day, {}.", name)
 ///             } else {
@@ -124,9 +122,9 @@ use std::collections::HashMap;
 ///         Ok(())
 ///     }
 ///     
-///     fn validate(&self, args: &HashMap<String, String>) -> Result<()> {
+///     fn validate(&self, args: &ParsedArgs) -> Result<()> {
 ///         // Custom validation: name must not be empty
-///         if let Some(name) = args.get("name") {
+///         if let Some(name) = args.get_scalar("name") {
 ///             if name.trim().is_empty() {
 ///                 return Err(ExecutionError::CommandFailed(
 ///                         anyhow::anyhow!("Name cannot be empty")
@@ -174,9 +172,8 @@ pub trait CommandHandler: Send + Sync {
     /// # Example
     ///
     /// ```
-    /// # use std::collections::HashMap;
     /// # use dynamic_cli::error::ExecutionError;
-    /// # use dynamic_cli::executor::CommandHandler;
+    /// # use dynamic_cli::executor::{CommandHandler, ParsedArgs};
     /// # use dynamic_cli::context::ExecutionContext;
     /// # use dynamic_cli::Result;
     /// #
@@ -186,9 +183,9 @@ pub trait CommandHandler: Send + Sync {
     ///     fn execute(
     ///         &self,
     ///         _context: &mut dyn ExecutionContext,
-    ///         args: &HashMap<String, String>,
+    ///         args: &ParsedArgs,
     ///     ) -> Result<()> {
-    ///         let path = args.get("path")
+    ///         let path = args.get_scalar("path")
     ///             .ok_or_else(|| {
     ///                ExecutionError::CommandFailed(
     ///                       anyhow::anyhow!("Missing path argument")
@@ -206,11 +203,7 @@ pub trait CommandHandler: Send + Sync {
     ///     }
     /// }
     /// ```
-    fn execute(
-        &self,
-        context: &mut dyn ExecutionContext,
-        args: &HashMap<String, String>,
-    ) -> Result<()>;
+    fn execute(&self, context: &mut dyn ExecutionContext, args: &ParsedArgs) -> Result<()>;
 
     /// Optional custom validation for arguments
     ///
@@ -235,8 +228,7 @@ pub trait CommandHandler: Send + Sync {
     /// # Example
     ///
     /// ```
-    /// # use std::collections::HashMap;
-    /// # use dynamic_cli::executor::CommandHandler;
+    /// # use dynamic_cli::executor::{CommandHandler, ParsedArgs};
     /// # use dynamic_cli::context::ExecutionContext;
     /// # use dynamic_cli::error::ExecutionError;
     /// # use dynamic_cli::Result;
@@ -247,15 +239,15 @@ pub trait CommandHandler: Send + Sync {
     ///     fn execute(
     ///         &self,
     ///         _context: &mut dyn ExecutionContext,
-    ///         args: &HashMap<String, String>,
+    ///         args: &ParsedArgs,
     ///     ) -> Result<()> {
     ///         // Execution logic here
     ///         Ok(())
     ///     }
     ///     
-    ///     fn validate(&self, args: &HashMap<String, String>) -> Result<()> {
+    ///     fn validate(&self, args: &ParsedArgs) -> Result<()> {
     ///         // Custom validation: ensure min < max
-    ///         if let (Some(min), Some(max)) = (args.get("min"), args.get("max")) {
+    ///         if let (Some(min), Some(max)) = (args.get_scalar("min"), args.get_scalar("max")) {
     ///             let min_val: f64 = min.parse()
     ///                 .map_err(|_| {
     ///                     ExecutionError::CommandFailed(anyhow::anyhow!("Invalid min value"))
@@ -271,7 +263,7 @@ pub trait CommandHandler: Send + Sync {
     ///     }
     /// }
     /// ```
-    fn validate(&self, _args: &HashMap<String, String>) -> Result<()> {
+    fn validate(&self, _args: &ParsedArgs) -> Result<()> {
         Ok(())
     }
 }
@@ -309,9 +301,8 @@ pub trait CommandHandler: Send + Sync {
 /// # Example
 ///
 /// ```
-/// use std::collections::HashMap;
 /// use async_trait::async_trait;
-/// use dynamic_cli::executor::AsyncCommandHandler;
+/// use dynamic_cli::executor::{AsyncCommandHandler, ParsedArgs};
 /// use dynamic_cli::context::ExecutionContext;
 /// use dynamic_cli::error::ExecutionError;
 /// use dynamic_cli::Result;
@@ -323,9 +314,9 @@ pub trait CommandHandler: Send + Sync {
 ///     async fn execute(
 ///         &self,
 ///         _context: &mut dyn ExecutionContext,
-///         args: &HashMap<String, String>,
+///         args: &ParsedArgs,
 ///     ) -> Result<()> {
-///         let url = args.get("url").ok_or_else(|| {
+///         let url = args.get_scalar("url").ok_or_else(|| {
 ///             ExecutionError::CommandFailed(anyhow::anyhow!("Missing 'url' argument"))
 ///         })?;
 ///         // Real implementations would `.await` an async HTTP call here.
@@ -333,8 +324,8 @@ pub trait CommandHandler: Send + Sync {
 ///         Ok(())
 ///     }
 ///
-///     async fn validate(&self, args: &HashMap<String, String>) -> Result<()> {
-///         if !args.contains_key("url") {
+///     async fn validate(&self, args: &ParsedArgs) -> Result<()> {
+///         if args.get_scalar("url").is_none() {
 ///             return Err(ExecutionError::CommandFailed(anyhow::anyhow!("url is required")).into());
 ///         }
 ///         Ok(())
@@ -346,16 +337,12 @@ pub trait AsyncCommandHandler: Send + Sync {
     /// Async equivalent of [`CommandHandler::execute`]. Same contract:
     /// receives the mutable execution context and the parsed arguments,
     /// returns `Ok(())` on success or a `DynamicCliError` on failure.
-    async fn execute(
-        &self,
-        context: &mut dyn ExecutionContext,
-        args: &HashMap<String, String>,
-    ) -> Result<()>;
+    async fn execute(&self, context: &mut dyn ExecutionContext, args: &ParsedArgs) -> Result<()>;
 
     /// Async equivalent of [`CommandHandler::validate`]. Same contract and
     /// same default (accepts all arguments) — override only for custom
     /// validation logic.
-    async fn validate(&self, _args: &HashMap<String, String>) -> Result<()> {
+    async fn validate(&self, _args: &ParsedArgs) -> Result<()> {
         Ok(())
     }
 }
@@ -365,7 +352,17 @@ mod tests {
     use super::*;
     use crate::error::ExecutionError;
     use std::any::Any;
-    use std::sync::{Arc, Mutex};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    /// Test helper: build a scalar-only `ParsedArgs` from `[(key, value), ...]`.
+    fn scalar_args<const N: usize>(pairs: [(&str, &str); N]) -> ParsedArgs {
+        let map: HashMap<String, String> = pairs
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        ParsedArgs::from_scalars(map)
+    }
 
     // ============================================================================
     // TEST FIXTURES
@@ -391,16 +388,12 @@ mod tests {
     struct HelloCommand;
 
     impl CommandHandler for HelloCommand {
-        fn execute(
-            &self,
-            context: &mut dyn ExecutionContext,
-            args: &HashMap<String, String>,
-        ) -> Result<()> {
+        fn execute(&self, context: &mut dyn ExecutionContext, args: &ParsedArgs) -> Result<()> {
             let ctx = crate::context::downcast_mut::<TestContext>(context).ok_or_else(|| {
                 ExecutionError::CommandFailed(anyhow::anyhow!("Wrong context type"))
             })?;
 
-            let name = args.get("name").map(|s| s.as_str()).unwrap_or("World");
+            let name = args.get_scalar("name").unwrap_or("World");
             ctx.state = format!("Hello, {}!", name);
             Ok(())
         }
@@ -410,17 +403,13 @@ mod tests {
     struct ValidatedCommand;
 
     impl CommandHandler for ValidatedCommand {
-        fn execute(
-            &self,
-            _context: &mut dyn ExecutionContext,
-            _args: &HashMap<String, String>,
-        ) -> Result<()> {
+        fn execute(&self, _context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
             Ok(())
         }
 
-        fn validate(&self, args: &HashMap<String, String>) -> Result<()> {
+        fn validate(&self, args: &ParsedArgs) -> Result<()> {
             // Require "count" argument to be present and > 0
-            if let Some(count) = args.get("count") {
+            if let Some(count) = args.get_scalar("count") {
                 let count_val: i32 = count.parse().map_err(|_| {
                     ExecutionError::CommandFailed(anyhow::anyhow!("count must be an integer"))
                 })?;
@@ -444,11 +433,7 @@ mod tests {
     struct FailingCommand;
 
     impl CommandHandler for FailingCommand {
-        fn execute(
-            &self,
-            _context: &mut dyn ExecutionContext,
-            _args: &HashMap<String, String>,
-        ) -> Result<()> {
+        fn execute(&self, _context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
             Err(ExecutionError::CommandFailed(anyhow::anyhow!("Simulated failure")).into())
         }
     }
@@ -457,16 +442,12 @@ mod tests {
     struct StatefulCommand;
 
     impl CommandHandler for StatefulCommand {
-        fn execute(
-            &self,
-            context: &mut dyn ExecutionContext,
-            args: &HashMap<String, String>,
-        ) -> Result<()> {
+        fn execute(&self, context: &mut dyn ExecutionContext, args: &ParsedArgs) -> Result<()> {
             let ctx = crate::context::downcast_mut::<TestContext>(context).ok_or_else(|| {
                 ExecutionError::CommandFailed(anyhow::anyhow!("Wrong context type"))
             })?;
 
-            let value = args.get("value").map(|s| s.as_str()).unwrap_or("default");
+            let value = args.get_scalar("value").unwrap_or("default");
             ctx.state.push_str(value);
             Ok(())
         }
@@ -480,8 +461,7 @@ mod tests {
     fn test_basic_execution() {
         let handler = HelloCommand;
         let mut context = TestContext::default();
-        let mut args = HashMap::new();
-        args.insert("name".to_string(), "Rust".to_string());
+        let args = scalar_args([("name", "Rust")]);
 
         let result = handler.execute(&mut context, &args);
 
@@ -493,7 +473,7 @@ mod tests {
     fn test_execution_without_args() {
         let handler = HelloCommand;
         let mut context = TestContext::default();
-        let args = HashMap::new();
+        let args = ParsedArgs::from_scalars(HashMap::new());
 
         let result = handler.execute(&mut context, &args);
 
@@ -505,8 +485,7 @@ mod tests {
     fn test_execution_with_empty_name() {
         let handler = HelloCommand;
         let mut context = TestContext::default();
-        let mut args = HashMap::new();
-        args.insert("name".to_string(), "".to_string());
+        let args = scalar_args([("name", "")]);
 
         let result = handler.execute(&mut context, &args);
 
@@ -521,8 +500,7 @@ mod tests {
     #[test]
     fn test_default_validation_accepts_all() {
         let handler = HelloCommand;
-        let mut args = HashMap::new();
-        args.insert("random".to_string(), "value".to_string());
+        let args = scalar_args([("random", "value")]);
 
         let result = handler.validate(&args);
 
@@ -532,8 +510,7 @@ mod tests {
     #[test]
     fn test_custom_validation_success() {
         let handler = ValidatedCommand;
-        let mut args = HashMap::new();
-        args.insert("count".to_string(), "5".to_string());
+        let args = scalar_args([("count", "5")]);
 
         let result = handler.validate(&args);
 
@@ -543,7 +520,7 @@ mod tests {
     #[test]
     fn test_custom_validation_missing_arg() {
         let handler = ValidatedCommand;
-        let args = HashMap::new();
+        let args = ParsedArgs::from_scalars(HashMap::new());
 
         let result = handler.validate(&args);
 
@@ -555,8 +532,7 @@ mod tests {
     #[test]
     fn test_custom_validation_invalid_value() {
         let handler = ValidatedCommand;
-        let mut args = HashMap::new();
-        args.insert("count".to_string(), "0".to_string());
+        let args = scalar_args([("count", "0")]);
 
         let result = handler.validate(&args);
 
@@ -568,8 +544,7 @@ mod tests {
     #[test]
     fn test_custom_validation_non_integer() {
         let handler = ValidatedCommand;
-        let mut args = HashMap::new();
-        args.insert("count".to_string(), "abc".to_string());
+        let args = scalar_args([("count", "abc")]);
 
         let result = handler.validate(&args);
 
@@ -586,7 +561,7 @@ mod tests {
     fn test_execution_failure() {
         let handler = FailingCommand;
         let mut context = TestContext::default();
-        let args = HashMap::new();
+        let args = ParsedArgs::from_scalars(HashMap::new());
 
         let result = handler.execute(&mut context, &args);
 
@@ -613,7 +588,7 @@ mod tests {
 
         let handler = HelloCommand;
         let mut wrong_context = WrongContext::default();
-        let args = HashMap::new();
+        let args = ParsedArgs::from_scalars(HashMap::new());
 
         let result = handler.execute(&mut wrong_context, &args);
 
@@ -631,8 +606,7 @@ mod tests {
         let handler = StatefulCommand;
         let mut context = TestContext::default();
         context.state = "initial".to_string();
-        let mut args = HashMap::new();
-        args.insert("value".to_string(), "_modified".to_string());
+        let args = scalar_args([("value", "_modified")]);
 
         let result = handler.execute(&mut context, &args);
 
@@ -646,14 +620,12 @@ mod tests {
         let mut context = TestContext::default();
 
         // First execution
-        let mut args1 = HashMap::new();
-        args1.insert("value".to_string(), "first".to_string());
+        let args1 = scalar_args([("value", "first")]);
         handler.execute(&mut context, &args1).unwrap();
         assert_eq!(context.state, "first");
 
         // Second execution
-        let mut args2 = HashMap::new();
-        args2.insert("value".to_string(), "_second".to_string());
+        let args2 = scalar_args([("value", "_second")]);
         handler.execute(&mut context, &args2).unwrap();
         assert_eq!(context.state, "first_second");
     }
@@ -667,8 +639,7 @@ mod tests {
         // Verify that CommandHandler can be used as a trait object
         let handler: Box<dyn CommandHandler> = Box::new(HelloCommand);
         let mut context = TestContext::default();
-        let mut args = HashMap::new();
-        args.insert("name".to_string(), "TraitObject".to_string());
+        let args = scalar_args([("name", "TraitObject")]);
 
         let result = handler.execute(&mut context, &args);
 
@@ -685,15 +656,13 @@ mod tests {
         let mut context = TestContext::default();
 
         // Execute first handler
-        let mut args1 = HashMap::new();
-        args1.insert("name".to_string(), "First".to_string());
+        let args1 = scalar_args([("name", "First")]);
         handlers[0].execute(&mut context, &args1).unwrap();
         assert_eq!(context.state, "Hello, First!");
 
         // Execute second handler
         context.state.clear();
-        let mut args2 = HashMap::new();
-        args2.insert("value".to_string(), "Second".to_string());
+        let args2 = scalar_args([("value", "Second")]);
         handlers[1].execute(&mut context, &args2).unwrap();
         assert_eq!(context.state, "Second");
     }
@@ -724,13 +693,11 @@ mod tests {
         let handler_clone = handler.clone();
 
         let handle = std::thread::spawn(move || {
-            let mut args = HashMap::new();
-            args.insert("count".to_string(), "10".to_string());
+            let args = scalar_args([("count", "10")]);
             handler_clone.validate(&args)
         });
 
-        let mut args = HashMap::new();
-        args.insert("count".to_string(), "5".to_string());
+        let args = scalar_args([("count", "5")]);
         let result1 = handler.validate(&args);
 
         let result2 = handle.join().unwrap();
@@ -747,7 +714,7 @@ mod tests {
     fn test_empty_args() {
         let handler = StatefulCommand;
         let mut context = TestContext::default();
-        let args = HashMap::new();
+        let args = ParsedArgs::from_scalars(HashMap::new());
 
         // Should use default value
         let result = handler.execute(&mut context, &args);
@@ -760,8 +727,7 @@ mod tests {
     fn test_args_with_special_characters() {
         let handler = HelloCommand;
         let mut context = TestContext::default();
-        let mut args = HashMap::new();
-        args.insert("name".to_string(), "Hello, 世界! 🌍".to_string());
+        let args = scalar_args([("name", "Hello, 世界! 🌍")]);
 
         let result = handler.execute(&mut context, &args);
 
@@ -773,9 +739,8 @@ mod tests {
     fn test_very_long_argument() {
         let handler = HelloCommand;
         let mut context = TestContext::default();
-        let mut args = HashMap::new();
         let long_name = "x".repeat(10000);
-        args.insert("name".to_string(), long_name.clone());
+        let args = scalar_args([("name", long_name.as_str())]);
 
         let result = handler.execute(&mut context, &args);
 
@@ -794,12 +759,10 @@ mod tests {
         let handler2 = StatefulCommand;
         let mut context = TestContext::default();
 
-        let mut args1 = HashMap::new();
-        args1.insert("value".to_string(), "A".to_string());
+        let args1 = scalar_args([("value", "A")]);
         handler1.execute(&mut context, &args1).unwrap();
 
-        let mut args2 = HashMap::new();
-        args2.insert("value".to_string(), "B".to_string());
+        let args2 = scalar_args([("value", "B")]);
         handler2.execute(&mut context, &args2).unwrap();
 
         assert_eq!(context.state, "AB");
@@ -845,12 +808,12 @@ mod tests {
         async fn execute(
             &self,
             context: &mut dyn ExecutionContext,
-            args: &HashMap<String, String>,
+            args: &ParsedArgs,
         ) -> Result<()> {
             let ctx = crate::context::downcast_mut::<TestContext>(context).ok_or_else(|| {
                 ExecutionError::CommandFailed(anyhow::anyhow!("Wrong context type"))
             })?;
-            let name = args.get("name").map(|s| s.as_str()).unwrap_or("World");
+            let name = args.get_scalar("name").unwrap_or("World");
             ctx.state = format!("Hello, {}!", name);
             Ok(())
         }
@@ -864,13 +827,13 @@ mod tests {
         async fn execute(
             &self,
             _context: &mut dyn ExecutionContext,
-            _args: &HashMap<String, String>,
+            _args: &ParsedArgs,
         ) -> Result<()> {
             Ok(())
         }
 
-        async fn validate(&self, args: &HashMap<String, String>) -> Result<()> {
-            if !args.contains_key("count") {
+        async fn validate(&self, args: &ParsedArgs) -> Result<()> {
+            if args.get_scalar("count").is_none() {
                 return Err(
                     ExecutionError::CommandFailed(anyhow::anyhow!("count is required")).into(),
                 );
@@ -887,7 +850,7 @@ mod tests {
         async fn execute(
             &self,
             _context: &mut dyn ExecutionContext,
-            _args: &HashMap<String, String>,
+            _args: &ParsedArgs,
         ) -> Result<()> {
             Err(ExecutionError::CommandFailed(anyhow::anyhow!("Simulated async failure")).into())
         }
@@ -897,8 +860,7 @@ mod tests {
     fn test_async_basic_execution() {
         let handler = AsyncHelloCommand;
         let mut context = TestContext::default();
-        let mut args = HashMap::new();
-        args.insert("name".to_string(), "Rust".to_string());
+        let args = scalar_args([("name", "Rust")]);
 
         let result = futures::executor::block_on(handler.execute(&mut context, &args));
 
@@ -909,8 +871,7 @@ mod tests {
     #[test]
     fn test_async_default_validation_accepts_all() {
         let handler = AsyncHelloCommand;
-        let mut args = HashMap::new();
-        args.insert("random".to_string(), "value".to_string());
+        let args = scalar_args([("random", "value")]);
 
         let result = futures::executor::block_on(handler.validate(&args));
 
@@ -920,7 +881,7 @@ mod tests {
     #[test]
     fn test_async_custom_validation_missing_arg() {
         let handler = AsyncValidatedCommand;
-        let args = HashMap::new();
+        let args = ParsedArgs::from_scalars(HashMap::new());
 
         let result = futures::executor::block_on(handler.validate(&args));
 
@@ -932,8 +893,7 @@ mod tests {
     #[test]
     fn test_async_custom_validation_success() {
         let handler = AsyncValidatedCommand;
-        let mut args = HashMap::new();
-        args.insert("count".to_string(), "5".to_string());
+        let args = scalar_args([("count", "5")]);
 
         let result = futures::executor::block_on(handler.validate(&args));
 
@@ -944,7 +904,7 @@ mod tests {
     fn test_async_execution_failure() {
         let handler = AsyncFailingCommand;
         let mut context = TestContext::default();
-        let args = HashMap::new();
+        let args = ParsedArgs::from_scalars(HashMap::new());
 
         let result = futures::executor::block_on(handler.execute(&mut context, &args));
 
@@ -959,8 +919,7 @@ mod tests {
         // the core object-safety guarantee DD-022 depends on.
         let handler: Box<dyn AsyncCommandHandler> = Box::new(AsyncHelloCommand);
         let mut context = TestContext::default();
-        let mut args = HashMap::new();
-        args.insert("name".to_string(), "TraitObject".to_string());
+        let args = scalar_args([("name", "TraitObject")]);
 
         let result = futures::executor::block_on(handler.execute(&mut context, &args));
 

--- a/src/help/mod.rs
+++ b/src/help/mod.rs
@@ -403,6 +403,7 @@ mod tests {
     use crate::config::schema::{
         ArgumentDefinition, ArgumentType, CommandDefinition, Metadata, OptionDefinition,
     };
+    use std::collections::HashMap;
 
     // Disable ANSI codes in tests so assertions work on plain text.
     fn no_color() {
@@ -443,6 +444,8 @@ mod tests {
                         default: None,
                         description: "Use uppercase".to_string(),
                         choices: vec![],
+                        repeatable: false,
+                        option_parameters: HashMap::new(),
                     }],
                     implementation: "hello_handler".to_string(),
                 },

--- a/src/interface/cli.rs
+++ b/src/interface/cli.rs
@@ -27,7 +27,7 @@
 
 use crate::context::ExecutionContext;
 use crate::error::{display_error, DynamicCliError, Result};
-use crate::parser::CliParser;
+use crate::parser::{CliParser, ParsedArgs};
 use crate::registry::CommandRegistry;
 use std::process;
 
@@ -166,9 +166,11 @@ impl CliInterface {
             DynamicCliError::Registry(crate::error::RegistryError::missing_handler(resolved_name))
         })?;
 
-        // Parse arguments using CLI parser
+        // Parse arguments using CLI parser (DD-024/#39: typed to preserve
+        // repeatable-option occurrences; ParsedArgs is the shape every
+        // handler now receives).
         let parser = CliParser::new(definition);
-        let parsed_args = parser.parse(&args[1..])?;
+        let parsed_args = ParsedArgs::new(parser.parse_typed(&args[1..])?);
 
         // Get handler and execute command. Sync is tried first (unchanged
         // behaviour); if no sync handler matches, fall through to the async
@@ -249,7 +251,6 @@ impl CliInterface {
 mod tests {
     use super::*;
     use crate::config::schema::{ArgumentDefinition, ArgumentType, CommandDefinition};
-    use std::collections::HashMap;
 
     // Test context
     #[derive(Default)]
@@ -273,11 +274,7 @@ mod tests {
     }
 
     impl crate::executor::CommandHandler for TestHandler {
-        fn execute(
-            &self,
-            context: &mut dyn ExecutionContext,
-            _args: &HashMap<String, String>,
-        ) -> Result<()> {
+        fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
             let ctx = crate::context::downcast_mut::<TestContext>(context)
                 .expect("Failed to downcast context");
             ctx.executed_command = Some(self.name.clone());
@@ -396,9 +393,9 @@ mod tests {
             fn execute(
                 &self,
                 _context: &mut dyn ExecutionContext,
-                args: &HashMap<String, String>,
+                args: &ParsedArgs,
             ) -> Result<()> {
-                assert_eq!(args.get("name"), Some(&"Alice".to_string()));
+                assert_eq!(args.get_scalar("name"), Some("Alice"));
                 Ok(())
             }
         }

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -117,7 +117,6 @@
 //! use dynamic_cli::prelude::*;
 //! use dynamic_cli::config::loader::load_config;
 //! use dynamic_cli::interface::CliInterface;
-//! use std::collections::HashMap;
 //!
 //! // Define context
 //! #[derive(Default)]
@@ -137,11 +136,11 @@
 //!     fn execute(
 //!         &self,
 //!         context: &mut dyn ExecutionContext,
-//!         args: &HashMap<String, String>,
+//!         args: &ParsedArgs,
 //!     ) -> dynamic_cli::Result<()> {
 //!         let ctx = dynamic_cli::context::downcast_mut::<AppContext>(context).unwrap();
-//!         let item = args.get("item").unwrap();
-//!         ctx.data.push(item.clone());
+//!         let item = args.get_scalar("item").unwrap();
+//!         ctx.data.push(item.to_string());
 //!         println!("Added: {}", item);
 //!         Ok(())
 //!     }
@@ -171,7 +170,6 @@
 //! use dynamic_cli::prelude::*;
 //! use dynamic_cli::config::loader::load_config;
 //! use dynamic_cli::interface::ReplInterface;
-//! use std::collections::HashMap;
 //!
 //! // Same context and handler as above
 //! # #[derive(Default)]
@@ -182,10 +180,10 @@
 //! # }
 //! # struct AddCommand;
 //! # impl CommandHandler for AddCommand {
-//! #     fn execute(&self, context: &mut dyn ExecutionContext, args: &HashMap<String, String>) -> dynamic_cli::Result<()> {
+//! #     fn execute(&self, context: &mut dyn ExecutionContext, args: &ParsedArgs) -> dynamic_cli::Result<()> {
 //! #         let ctx = dynamic_cli::context::downcast_mut::<AppContext>(context).unwrap();
-//! #         let item = args.get("item").unwrap();
-//! #         ctx.data.push(item.clone());
+//! #         let item = args.get_scalar("item").unwrap();
+//! #         ctx.data.push(item.to_string());
 //! #         println!("Added: {}", item);
 //! #         Ok(())
 //! #     }
@@ -229,7 +227,6 @@ mod tests {
     use super::*;
     use crate::config::schema::CommandDefinition;
     use crate::prelude::*;
-    use std::collections::HashMap;
 
     // Test context
     #[derive(Default)]
@@ -252,7 +249,7 @@ mod tests {
         fn execute(
             &self,
             _context: &mut dyn ExecutionContext,
-            _args: &HashMap<String, String>,
+            _args: &ParsedArgs,
         ) -> crate::Result<()> {
             Ok(())
         }

--- a/src/interface/repl.rs
+++ b/src/interface/repl.rs
@@ -42,7 +42,7 @@ use crate::config::schema::CommandsConfig;
 use crate::context::ExecutionContext;
 use crate::error::{display_error, DynamicCliError, ExecutionError, Result};
 use crate::help::HelpFormatter;
-use crate::parser::ReplParser;
+use crate::parser::{ParsedArgs, ReplParser};
 use crate::registry::CommandRegistry;
 
 // ============================================================================
@@ -593,10 +593,18 @@ impl ReplInterface {
         // — one command finishes (readline blocks regardless) before the
         // next line is even read, so there is no other async task waiting
         // that `block_on` could starve.
+        //
+        // Wrapped via `from_scalars`: `ReplParser::parse_line` still
+        // produces a plain `HashMap<String, String>` (DD-024 addendum —
+        // repeatable options have no interactive REPL-typing use case, see
+        // `DESIGN_DECISIONS.md`). Every handler receives `&ParsedArgs`
+        // regardless of dispatch path (#39); the REPL path just never
+        // populates `ParsedValue::Repeated` entries.
+        let parsed_args = ParsedArgs::from_scalars(parsed.arguments);
         if let Some(handler) = self.registry.get_handler_sync(&parsed.command_name) {
-            handler.execute(&mut *self.context, &parsed.arguments)?;
+            handler.execute(&mut *self.context, &parsed_args)?;
         } else if let Some(handler) = self.registry.get_handler_async(&parsed.command_name) {
-            futures::executor::block_on(handler.execute(&mut *self.context, &parsed.arguments))?;
+            futures::executor::block_on(handler.execute(&mut *self.context, &parsed_args))?;
         } else {
             return Err(DynamicCliError::Execution(
                 ExecutionError::handler_not_found(&parsed.command_name, "unknown"),
@@ -645,11 +653,7 @@ mod tests {
     }
 
     impl crate::executor::CommandHandler for TestHandler {
-        fn execute(
-            &self,
-            context: &mut dyn ExecutionContext,
-            _args: &HashMap<String, String>,
-        ) -> Result<()> {
+        fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
             let ctx = crate::context::downcast_mut::<TestContext>(context)
                 .expect("Failed to downcast context");
             ctx.executed_commands.push(self.name.clone());
@@ -798,12 +802,8 @@ mod tests {
 
         struct GreetHandler;
         impl crate::executor::CommandHandler for GreetHandler {
-            fn execute(
-                &self,
-                _ctx: &mut dyn ExecutionContext,
-                args: &HashMap<String, String>,
-            ) -> Result<()> {
-                assert_eq!(args.get("name"), Some(&"Alice".to_string()));
+            fn execute(&self, _ctx: &mut dyn ExecutionContext, args: &ParsedArgs) -> Result<()> {
+                assert_eq!(args.get_scalar("name"), Some("Alice"));
                 Ok(())
             }
         }
@@ -1019,11 +1019,7 @@ mod tests {
         let cmd_def = make_help_config().commands.into_iter().next().unwrap();
         struct DummyHandler;
         impl crate::executor::CommandHandler for DummyHandler {
-            fn execute(
-                &self,
-                _: &mut dyn ExecutionContext,
-                _: &HashMap<String, String>,
-            ) -> Result<()> {
+            fn execute(&self, _: &mut dyn ExecutionContext, _: &ParsedArgs) -> Result<()> {
                 Ok(())
             }
         }
@@ -1054,11 +1050,7 @@ mod tests {
         let cmd_def = make_help_config().commands.into_iter().next().unwrap();
         struct DummyHandler;
         impl crate::executor::CommandHandler for DummyHandler {
-            fn execute(
-                &self,
-                _: &mut dyn ExecutionContext,
-                _: &HashMap<String, String>,
-            ) -> Result<()> {
+            fn execute(&self, _: &mut dyn ExecutionContext, _: &ParsedArgs) -> Result<()> {
                 Ok(())
             }
         }
@@ -1125,11 +1117,7 @@ mod tests {
 
         struct LoginHandler;
         impl crate::executor::CommandHandler for LoginHandler {
-            fn execute(
-                &self,
-                _ctx: &mut dyn ExecutionContext,
-                _args: &HashMap<String, String>,
-            ) -> Result<()> {
+            fn execute(&self, _ctx: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
                 Ok(())
             }
         }

--- a/src/interface/repl.rs
+++ b/src/interface/repl.rs
@@ -702,6 +702,8 @@ mod tests {
                     default: Some("false".to_string()),
                     description: "Loud greeting".to_string(),
                     choices: vec![],
+                    repeatable: false,
+                    option_parameters: HashMap::new(),
                 }],
                 implementation: "hello_handler".to_string(),
             }],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@
 //!
 //! ```no_run
 //! use dynamic_cli::prelude::*;
-//! use std::collections::HashMap;
 //!
 //! // 1. Define the execution context
 //! #[derive(Default)]
@@ -35,10 +34,9 @@
 //!     fn execute(
 //!         &self,
 //!         _context: &mut dyn ExecutionContext,
-//!         args: &HashMap<String, String>,
+//!         args: &ParsedArgs,
 //!     ) -> dynamic_cli::Result<()> {
-//!         let default_name = "World".to_string();
-//!         let name = args.get("name").unwrap_or(&default_name);
+//!         let name = args.get_scalar("name").unwrap_or("World");
 //!         println!("Hello, {}!", name);
 //!         Ok(())
 //!     }
@@ -58,7 +56,8 @@
 //!
 //! let mut context = MyContext::default();
 //! let handler = registry.get_handler_sync(&parsed.command_name).unwrap();
-//! handler.execute(&mut context, &parsed.arguments)?;
+//! let args = ParsedArgs::from_scalars(parsed.arguments);
+//! handler.execute(&mut context, &args)?;
 //! # Ok(())
 //! # }
 //! ```
@@ -121,7 +120,7 @@ pub use config::schema::{
 pub use registry::CommandRegistry;
 
 // Parser types
-pub use parser::{CliParser, ParsedCommand, ReplParser};
+pub use parser::{CliParser, ParsedArgs, ParsedCommand, ReplParser};
 
 // Validator functions
 pub use validator::{validate_file_exists, validate_file_extension, validate_range};
@@ -188,7 +187,7 @@ pub mod prelude {
     pub use crate::registry::CommandRegistry;
 
     // Parsing
-    pub use crate::parser::{CliParser, ParsedCommand, ReplParser};
+    pub use crate::parser::{CliParser, ParsedArgs, ParsedCommand, ReplParser};
 
     // Validation
     pub use crate::validator::{validate_file_exists, validate_file_extension, validate_range};

--- a/src/parser/cli_parser.rs
+++ b/src/parser/cli_parser.rs
@@ -64,6 +64,7 @@ use std::collections::HashMap;
 /// use dynamic_cli::config::schema::{
 ///     CommandDefinition, OptionDefinition, ArgumentType
 /// };
+/// use std::collections::HashMap;
 ///
 /// let definition = CommandDefinition {
 ///     name: "test".to_string(),
@@ -81,6 +82,8 @@ use std::collections::HashMap;
 ///             default: Some("false".to_string()),
 ///             description: "Verbose output".to_string(),
 ///             choices: vec![],
+///             repeatable: false,
+///             option_parameters: HashMap::new(),
 ///         }
 ///     ],
 ///     implementation: "handler".to_string(),
@@ -475,6 +478,8 @@ mod tests {
                     default: Some("false".to_string()),
                     description: "Verbose output".to_string(),
                     choices: vec![],
+                    repeatable: false,
+                    option_parameters: HashMap::new(),
                 },
                 OptionDefinition {
                     name: "count".to_string(),
@@ -485,6 +490,8 @@ mod tests {
                     default: Some("10".to_string()),
                     description: "Count".to_string(),
                     choices: vec![],
+                    repeatable: false,
+                    option_parameters: HashMap::new(),
                 },
             ],
             implementation: "handler".to_string(),

--- a/src/parser/cli_parser.rs
+++ b/src/parser/cli_parser.rs
@@ -169,8 +169,10 @@ impl<'a> CliParser<'a> {
     /// (i.e. any `repeatable: true` option) is silently dropped from the
     /// result — no command definition predating DD-024 can have one, so
     /// existing callers see no behaviour change. Once the dispatch layer
-    /// is migrated to consume `ParsedArgs` directly (planned, DD-024,
-    /// tracked as a separate breaking change), this method can be removed.
+    /// is migrated to consume [`crate::parser::ParsedArgs`] directly
+    /// (#39, in progress — the type exists but `interface/cli.rs` and
+    /// `interface/repl.rs` still call this method, not `parse_typed`),
+    /// this method can be removed.
     ///
     /// # Arguments
     ///

--- a/src/parser/cli_parser.rs
+++ b/src/parser/cli_parser.rs
@@ -100,6 +100,40 @@ pub struct CliParser<'a> {
     definition: &'a CommandDefinition,
 }
 
+/// A single occurrence of a repeatable option
+///
+/// Produced when a `repeatable: true` option is encountered on the
+/// command line: `--output csv file=results.csv resolution=100` becomes
+/// `OptionOccurrence { discriminant: "csv", params: {"file": "results.csv",
+/// "resolution": "100"} }`.
+///
+/// `params` values are stored as strings after type validation against
+/// `option_parameters[discriminant]`, consistent with how scalar option
+/// and argument values are stored (see [`ParsedValue::Scalar`]).
+#[derive(Debug, Clone, PartialEq)]
+pub struct OptionOccurrence {
+    /// The token immediately following the flag, validated against the
+    /// option's `choices`.
+    pub discriminant: String,
+    /// The `key=value` pairs supplied for this occurrence.
+    pub params: HashMap<String, String>,
+}
+
+/// The value parsed for a single positional argument or option
+///
+/// [`CliParser::parse_typed`] returns `HashMap<String, ParsedValue>` so
+/// that repeatable options (which may occur zero or more times, each
+/// with their own sub-parameters) and plain scalar values can coexist in
+/// a single result map. [`CliParser::parse`] remains additive and
+/// unaffected — see its docs for how the two relate.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ParsedValue {
+    /// A plain positional argument or non-repeatable option value.
+    Scalar(String),
+    /// Every occurrence of a repeatable option, in command-line order.
+    Repeated(Vec<OptionOccurrence>),
+}
+
 impl<'a> CliParser<'a> {
     /// Create a new CLI parser for the given command definition
     ///
@@ -128,11 +162,15 @@ impl<'a> CliParser<'a> {
         Self { definition }
     }
 
-    /// Parse command-line arguments into a HashMap
+    /// Parse command-line arguments into a HashMap of strings
     ///
-    /// Parses the provided arguments according to the command definition.
-    /// Positional arguments are matched in order, and options are matched
-    /// by their short or long forms.
+    /// Thin, non-breaking wrapper around [`Self::parse_typed`] for callers
+    /// that only deal in scalar values. Any [`ParsedValue::Repeated`] entry
+    /// (i.e. any `repeatable: true` option) is silently dropped from the
+    /// result — no command definition predating DD-024 can have one, so
+    /// existing callers see no behaviour change. Once the dispatch layer
+    /// is migrated to consume `ParsedArgs` directly (planned, DD-024,
+    /// tracked as a separate breaking change), this method can be removed.
     ///
     /// # Arguments
     ///
@@ -183,6 +221,40 @@ impl<'a> CliParser<'a> {
     /// assert_eq!(result.get("name"), Some(&"Alice".to_string()));
     /// ```
     pub fn parse(&self, args: &[String]) -> Result<HashMap<String, String>> {
+        let typed = self.parse_typed(args)?;
+
+        Ok(typed
+            .into_iter()
+            .filter_map(|(name, value)| match value {
+                ParsedValue::Scalar(s) => Some((name, s)),
+                ParsedValue::Repeated(_) => None,
+            })
+            .collect())
+    }
+
+    /// Parse command-line arguments into a HashMap of [`ParsedValue`]
+    ///
+    /// Like [`Self::parse`], but preserves repeatable options as
+    /// [`ParsedValue::Repeated`] instead of dropping them. This is the
+    /// method that actually implements DD-024 parsing; `parse()` is a
+    /// filtering wrapper around it.
+    ///
+    /// # Arguments
+    ///
+    /// * `args` - Slice of argument strings (excluding the command name)
+    ///
+    /// # Errors
+    ///
+    /// In addition to the errors documented on [`Self::parse`]:
+    /// - [`ParseError::UnknownDiscriminant`] if the token following a
+    ///   repeatable option's flag is not in that option's `choices`
+    /// - [`ParseError::UnknownOptionParameter`] if a `key=value` pair uses
+    ///   a key not declared in `option_parameters[discriminant]`
+    /// - [`ParseError::MissingRequiredOptionParameter`] if a required key
+    ///   is absent from an occurrence
+    /// - [`ParseError::DuplicateOptionOccurrence`] if the same
+    ///   discriminant is supplied twice with identical `key=value` pairs
+    pub fn parse_typed(&self, args: &[String]) -> Result<HashMap<String, ParsedValue>> {
         let mut result = HashMap::new();
         let mut positional_index = 0;
         let mut i = 0;
@@ -233,7 +305,7 @@ impl<'a> CliParser<'a> {
         arg: &str,
         args: &[String],
         index: &mut usize,
-        result: &mut HashMap<String, String>,
+        result: &mut HashMap<String, ParsedValue>,
     ) -> Result<()> {
         let arg_without_dashes = &arg[2..];
 
@@ -243,18 +315,36 @@ impl<'a> CliParser<'a> {
             let value = &arg_without_dashes[eq_pos + 1..];
 
             let option = self.find_option_by_long(option_name)?;
+            if option.repeatable {
+                // A repeatable option's discriminant/params are never
+                // attached via `=` — only the space-separated form is
+                // supported (see parse_repeatable_occurrence).
+                return Err(ParseError::InvalidSyntax {
+                    details: format!(
+                        "Option --{} is repeatable and does not support --{}=<value>",
+                        option.name, option.name
+                    ),
+                    hint: Some(format!(
+                        "Usage: --{} <{}> [key=value ...]",
+                        option.name,
+                        option.choices.join("|")
+                    )),
+                }
+                .into());
+            }
             let parsed_value = type_parser::parse_value(value, option.option_type)?;
-            result.insert(option.name.clone(), parsed_value);
+            result.insert(option.name.clone(), ParsedValue::Scalar(parsed_value));
         } else {
             // --option format (value might be next arg)
             let option = self.find_option_by_long(arg_without_dashes)?;
 
-            // For boolean options, presence means true
-            if matches!(
+            if option.repeatable {
+                self.parse_repeatable_occurrence(option, args, index, result)?;
+            } else if matches!(
                 option.option_type,
                 crate::config::schema::ArgumentType::Bool
             ) {
-                result.insert(option.name.clone(), "true".to_string());
+                result.insert(option.name.clone(), ParsedValue::Scalar("true".to_string()));
             } else {
                 // Non-boolean: expect value in next argument
                 *index += 1;
@@ -275,7 +365,7 @@ impl<'a> CliParser<'a> {
 
                 let value = &args[*index];
                 let parsed_value = type_parser::parse_value(value, option.option_type)?;
-                result.insert(option.name.clone(), parsed_value);
+                result.insert(option.name.clone(), ParsedValue::Scalar(parsed_value));
             }
         }
 
@@ -288,23 +378,38 @@ impl<'a> CliParser<'a> {
         arg: &str,
         args: &[String],
         index: &mut usize,
-        result: &mut HashMap<String, String>,
+        result: &mut HashMap<String, ParsedValue>,
     ) -> Result<()> {
         let short_flag = &arg[1..2];
         let option = self.find_option_by_short(short_flag)?;
 
-        // For boolean options, presence means true
-        if matches!(
+        if option.repeatable {
+            if arg.len() > 2 {
+                return Err(ParseError::InvalidSyntax {
+                    details: format!(
+                        "Option -{} is repeatable and does not support an attached value",
+                        short_flag
+                    ),
+                    hint: Some(format!(
+                        "Usage: -{} <{}> [key=value ...]",
+                        short_flag,
+                        option.choices.join("|")
+                    )),
+                }
+                .into());
+            }
+            self.parse_repeatable_occurrence(option, args, index, result)?;
+        } else if matches!(
             option.option_type,
             crate::config::schema::ArgumentType::Bool
         ) {
-            result.insert(option.name.clone(), "true".to_string());
+            result.insert(option.name.clone(), ParsedValue::Scalar("true".to_string()));
         } else {
             // Check if value is attached (e.g., -ovalue)
             if arg.len() > 2 {
                 let value = &arg[2..];
                 let parsed_value = type_parser::parse_value(value, option.option_type)?;
-                result.insert(option.name.clone(), parsed_value);
+                result.insert(option.name.clone(), ParsedValue::Scalar(parsed_value));
             } else {
                 // Value is next argument
                 *index += 1;
@@ -321,7 +426,7 @@ impl<'a> CliParser<'a> {
 
                 let value = &args[*index];
                 let parsed_value = type_parser::parse_value(value, option.option_type)?;
-                result.insert(option.name.clone(), parsed_value);
+                result.insert(option.name.clone(), ParsedValue::Scalar(parsed_value));
             }
         }
 
@@ -333,7 +438,7 @@ impl<'a> CliParser<'a> {
         &self,
         value: &str,
         index: usize,
-        result: &mut HashMap<String, String>,
+        result: &mut HashMap<String, ParsedValue>,
     ) -> Result<()> {
         if index >= self.definition.arguments.len() {
             return Err(ParseError::too_many_arguments(
@@ -346,19 +451,168 @@ impl<'a> CliParser<'a> {
 
         let arg_def = &self.definition.arguments[index];
         let parsed_value = type_parser::parse_value(value, arg_def.arg_type)?;
-        result.insert(arg_def.name.clone(), parsed_value);
+        result.insert(arg_def.name.clone(), ParsedValue::Scalar(parsed_value));
+
+        Ok(())
+    }
+
+    /// Parse one occurrence of a repeatable option
+    ///
+    /// On entry, `index` points at the option's flag token. Reads the
+    /// discriminant token immediately following it, validates it against
+    /// `option.choices`, then consumes `key=value` tokens until the next
+    /// flag (any token starting with `-`) or the end of input — a
+    /// `key=value` pair can never start with `-` itself, so this is
+    /// unambiguous, unlike the top-level positional/negative-number case.
+    ///
+    /// On return, `index` points at the last token consumed (the
+    /// discriminant if no parameters followed, or the last `key=value`
+    /// token), matching the convention already used by
+    /// [`Self::parse_long_option`] / [`Self::parse_short_option`] — the
+    /// caller's own `i += 1` advances past it.
+    fn parse_repeatable_occurrence(
+        &self,
+        option: &OptionDefinition,
+        args: &[String],
+        index: &mut usize,
+        result: &mut HashMap<String, ParsedValue>,
+    ) -> Result<()> {
+        // Read the discriminant token.
+        *index += 1;
+        if *index >= args.len() {
+            return Err(ParseError::InvalidSyntax {
+                details: format!("Option --{} requires a discriminant", option.name),
+                hint: Some(format!(
+                    "Usage: --{} <{}> [key=value ...]",
+                    option.name,
+                    option.choices.join("|")
+                )),
+            }
+            .into());
+        }
+        let discriminant = args[*index].clone();
+        if !option.choices.contains(&discriminant) {
+            return Err(ParseError::UnknownDiscriminant {
+                option: option.name.clone(),
+                value: discriminant,
+                valid_choices: option.choices.clone(),
+                suggestion: Some(format!(
+                    "Run --help {} to see valid --{} kinds.",
+                    self.definition.name, option.name
+                )),
+            }
+            .into());
+        }
+
+        // Guaranteed present by validate_options() (#36) once
+        // repeatable/choices/option_parameters consistency has been
+        // validated at config-load time.
+        let empty: Vec<ArgumentDefinition> = Vec::new();
+        let param_defs = option
+            .option_parameters
+            .get(&discriminant)
+            .unwrap_or(&empty);
+
+        // Consume key=value tokens until the next flag or end of input.
+        let mut params: HashMap<String, String> = HashMap::new();
+        while *index + 1 < args.len() {
+            let next = &args[*index + 1];
+            if next.starts_with('-') {
+                break;
+            }
+
+            let eq_pos = match next.find('=') {
+                Some(pos) => pos,
+                None => {
+                    return Err(ParseError::InvalidSyntax {
+                        details: format!(
+                            "Expected key=value for --{} {}, got: '{}'",
+                            option.name, discriminant, next
+                        ),
+                        hint: Some("Sub-parameters must use the key=value form.".to_string()),
+                    }
+                    .into());
+                }
+            };
+            let key = &next[..eq_pos];
+            let value = &next[eq_pos + 1..];
+
+            let arg_def = param_defs.iter().find(|a| a.name == key).ok_or_else(|| {
+                ParseError::UnknownOptionParameter {
+                    option: option.name.clone(),
+                    discriminant: discriminant.clone(),
+                    key: key.to_string(),
+                    valid_keys: param_defs.iter().map(|a| a.name.clone()).collect(),
+                    suggestion: Some(format!(
+                        "Run --help {} to see valid keys for --{} {}.",
+                        self.definition.name, option.name, discriminant
+                    )),
+                }
+            })?;
+
+            let typed_value = type_parser::parse_value(value, arg_def.arg_type)?;
+            params.insert(key.to_string(), typed_value);
+
+            *index += 1;
+        }
+
+        // Validate required keys are present.
+        for arg_def in param_defs {
+            if arg_def.required && !params.contains_key(&arg_def.name) {
+                return Err(ParseError::MissingRequiredOptionParameter {
+                    option: option.name.clone(),
+                    discriminant: discriminant.clone(),
+                    key: arg_def.name.clone(),
+                    suggestion: Some(format!(
+                        "Run --help {} to see required keys for --{} {}.",
+                        self.definition.name, option.name, discriminant
+                    )),
+                }
+                .into());
+            }
+        }
+
+        let occurrence = OptionOccurrence {
+            discriminant: discriminant.clone(),
+            params,
+        };
+
+        match result
+            .entry(option.name.clone())
+            .or_insert_with(|| ParsedValue::Repeated(Vec::new()))
+        {
+            ParsedValue::Repeated(occurrences) => {
+                if occurrences.contains(&occurrence) {
+                    return Err(ParseError::DuplicateOptionOccurrence {
+                        option: option.name.clone(),
+                        discriminant: occurrence.discriminant.clone(),
+                        params: occurrence.params.clone().into_iter().collect(),
+                        suggestion: Some(format!(
+                            "Remove one of the two identical --{} {} occurrences.",
+                            option.name, discriminant
+                        )),
+                    }
+                    .into());
+                }
+                occurrences.push(occurrence);
+            }
+            ParsedValue::Scalar(_) => unreachable!(
+                "option '{}' marked repeatable cannot already hold a Scalar value",
+                option.name
+            ),
+        }
 
         Ok(())
     }
 
     /// Apply default values for options not provided
-    fn apply_defaults(&self, result: &mut HashMap<String, String>) -> Result<()> {
+    fn apply_defaults(&self, result: &mut HashMap<String, ParsedValue>) -> Result<()> {
         for option in &self.definition.options {
             if !result.contains_key(&option.name) {
                 if let Some(ref default) = option.default {
                     // Validate the default value
                     let parsed_default = type_parser::parse_value(default, option.option_type)?;
-                    result.insert(option.name.clone(), parsed_default);
+                    result.insert(option.name.clone(), ParsedValue::Scalar(parsed_default));
                 }
             }
         }
@@ -366,7 +620,7 @@ impl<'a> CliParser<'a> {
     }
 
     /// Validate that all required arguments are present
-    fn validate_required_arguments(&self, result: &HashMap<String, String>) -> Result<()> {
+    fn validate_required_arguments(&self, result: &HashMap<String, ParsedValue>) -> Result<()> {
         for arg in &self.definition.arguments {
             if arg.required && !result.contains_key(&arg.name) {
                 return Err(ParseError::missing_argument(&arg.name, &self.definition.name).into());
@@ -376,7 +630,7 @@ impl<'a> CliParser<'a> {
     }
 
     /// Validate that all required options are present
-    fn validate_required_options(&self, result: &HashMap<String, String>) -> Result<()> {
+    fn validate_required_options(&self, result: &HashMap<String, ParsedValue>) -> Result<()> {
         for option in &self.definition.options {
             if option.required && !result.contains_key(&option.name) {
                 return Err(ParseError::missing_option(
@@ -765,5 +1019,302 @@ mod tests {
         assert_eq!(result.get("output"), Some(&"output.txt".to_string()));
         assert_eq!(result.get("verbose"), Some(&"true".to_string()));
         assert_eq!(result.get("count"), Some(&"50".to_string()));
+    }
+
+    // ========================================================================
+    // DD-024: repeatable options with option_parameters (#38)
+    // ========================================================================
+
+    /// Helper: a command with a repeatable `--output` option, mirroring
+    /// the chrom-rs motivating example (csv with an optional resolution,
+    /// plot with just a file).
+    fn create_repeatable_test_definition() -> CommandDefinition {
+        let mut option_parameters = HashMap::new();
+        option_parameters.insert(
+            "csv".to_string(),
+            vec![
+                ArgumentDefinition {
+                    name: "file".to_string(),
+                    arg_type: ArgumentType::Path,
+                    required: true,
+                    description: "Destination CSV file".to_string(),
+                    validation: vec![],
+                    secure: false,
+                },
+                ArgumentDefinition {
+                    name: "resolution".to_string(),
+                    arg_type: ArgumentType::Integer,
+                    required: false,
+                    description: "Time-step resolution".to_string(),
+                    validation: vec![],
+                    secure: false,
+                },
+            ],
+        );
+        option_parameters.insert(
+            "plot".to_string(),
+            vec![ArgumentDefinition {
+                name: "file".to_string(),
+                arg_type: ArgumentType::Path,
+                required: true,
+                description: "Destination image file".to_string(),
+                validation: vec![],
+                secure: false,
+            }],
+        );
+
+        CommandDefinition {
+            name: "export".to_string(),
+            aliases: vec![],
+            description: "Export simulation results".to_string(),
+            required: false,
+            arguments: vec![],
+            options: vec![OptionDefinition {
+                name: "output".to_string(),
+                short: None,
+                long: Some("output".to_string()),
+                option_type: ArgumentType::String,
+                required: false,
+                default: None,
+                description: "Write results in one or more output kinds".to_string(),
+                choices: vec!["csv".to_string(), "plot".to_string()],
+                repeatable: true,
+                option_parameters,
+            }],
+            implementation: "export_handler".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_parse_repeatable_option_single_occurrence() {
+        let definition = create_repeatable_test_definition();
+        let parser = CliParser::new(&definition);
+
+        let args = vec![
+            "--output".to_string(),
+            "csv".to_string(),
+            "file=results.csv".to_string(),
+        ];
+        let result = parser.parse_typed(&args).unwrap();
+
+        match result.get("output") {
+            Some(ParsedValue::Repeated(occurrences)) => {
+                assert_eq!(occurrences.len(), 1);
+                assert_eq!(occurrences[0].discriminant, "csv");
+                assert_eq!(
+                    occurrences[0].params.get("file"),
+                    Some(&"results.csv".to_string())
+                );
+            }
+            other => panic!("Expected Repeated([csv]), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_repeatable_option_optional_param_can_be_omitted() {
+        let definition = create_repeatable_test_definition();
+        let parser = CliParser::new(&definition);
+
+        let args = vec![
+            "--output".to_string(),
+            "csv".to_string(),
+            "file=results.csv".to_string(),
+        ];
+        let result = parser.parse_typed(&args).unwrap();
+
+        match result.get("output") {
+            Some(ParsedValue::Repeated(occurrences)) => {
+                assert_eq!(occurrences[0].params.get("resolution"), None);
+            }
+            other => panic!("Expected Repeated([csv]), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_repeatable_option_with_optional_param_provided() {
+        let definition = create_repeatable_test_definition();
+        let parser = CliParser::new(&definition);
+
+        let args = vec![
+            "--output".to_string(),
+            "csv".to_string(),
+            "file=results.csv".to_string(),
+            "resolution=100".to_string(),
+        ];
+        let result = parser.parse_typed(&args).unwrap();
+
+        match result.get("output") {
+            Some(ParsedValue::Repeated(occurrences)) => {
+                assert_eq!(
+                    occurrences[0].params.get("resolution"),
+                    Some(&"100".to_string())
+                );
+            }
+            other => panic!("Expected Repeated([csv]), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_repeatable_option_multiple_discriminants_both_parse() {
+        let definition = create_repeatable_test_definition();
+        let parser = CliParser::new(&definition);
+
+        let args = vec![
+            "--output".to_string(),
+            "csv".to_string(),
+            "file=results.csv".to_string(),
+            "--output".to_string(),
+            "plot".to_string(),
+            "file=chart.png".to_string(),
+        ];
+        let result = parser.parse_typed(&args).unwrap();
+
+        match result.get("output") {
+            Some(ParsedValue::Repeated(occurrences)) => {
+                assert_eq!(occurrences.len(), 2);
+                assert_eq!(occurrences[0].discriminant, "csv");
+                assert_eq!(occurrences[1].discriminant, "plot");
+            }
+            other => panic!("Expected Repeated([csv, plot]), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_repeatable_option_same_discriminant_different_params_both_kept() {
+        let definition = create_repeatable_test_definition();
+        let parser = CliParser::new(&definition);
+
+        let args = vec![
+            "--output".to_string(),
+            "csv".to_string(),
+            "file=a.csv".to_string(),
+            "--output".to_string(),
+            "csv".to_string(),
+            "file=b.csv".to_string(),
+            "resolution=50".to_string(),
+        ];
+        let result = parser.parse_typed(&args).unwrap();
+
+        match result.get("output") {
+            Some(ParsedValue::Repeated(occurrences)) => {
+                assert_eq!(occurrences.len(), 2);
+            }
+            other => panic!("Expected Repeated([csv, csv]), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_repeatable_option_duplicate_occurrence_errors() {
+        let definition = create_repeatable_test_definition();
+        let parser = CliParser::new(&definition);
+
+        let args = vec![
+            "--output".to_string(),
+            "csv".to_string(),
+            "file=a.csv".to_string(),
+            "--output".to_string(),
+            "csv".to_string(),
+            "file=a.csv".to_string(),
+        ];
+        let result = parser.parse_typed(&args);
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            crate::error::DynamicCliError::Parse(ParseError::DuplicateOptionOccurrence {
+                ..
+            }) => {}
+            other => panic!("Expected DuplicateOptionOccurrence error, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_repeatable_option_missing_required_param_errors() {
+        let definition = create_repeatable_test_definition();
+        let parser = CliParser::new(&definition);
+
+        // "file" is required for the csv discriminant and is not supplied.
+        let args = vec!["--output".to_string(), "csv".to_string()];
+        let result = parser.parse_typed(&args);
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            crate::error::DynamicCliError::Parse(ParseError::MissingRequiredOptionParameter {
+                key,
+                ..
+            }) => {
+                assert_eq!(key, "file");
+            }
+            other => panic!(
+                "Expected MissingRequiredOptionParameter error, got {:?}",
+                other
+            ),
+        }
+    }
+
+    #[test]
+    fn test_parse_repeatable_option_unknown_param_key_errors() {
+        let definition = create_repeatable_test_definition();
+        let parser = CliParser::new(&definition);
+
+        let args = vec![
+            "--output".to_string(),
+            "csv".to_string(),
+            "file=a.csv".to_string(),
+            "compression=gzip".to_string(),
+        ];
+        let result = parser.parse_typed(&args);
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            crate::error::DynamicCliError::Parse(ParseError::UnknownOptionParameter {
+                key,
+                ..
+            }) => {
+                assert_eq!(key, "compression");
+            }
+            other => panic!("Expected UnknownOptionParameter error, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_repeatable_option_unknown_discriminant_errors() {
+        let definition = create_repeatable_test_definition();
+        let parser = CliParser::new(&definition);
+
+        let args = vec![
+            "--output".to_string(),
+            "xml".to_string(),
+            "file=a.xml".to_string(),
+        ];
+        let result = parser.parse_typed(&args);
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            crate::error::DynamicCliError::Parse(ParseError::UnknownDiscriminant {
+                value, ..
+            }) => {
+                assert_eq!(value, "xml");
+            }
+            other => panic!("Expected UnknownDiscriminant error, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_legacy_drops_repeated_values() {
+        // parse() (Option A design: non-breaking wrapper) must keep
+        // working for definitions with no repeatable options — and
+        // silently drop Repeated entries rather than erroring, since no
+        // pre-DD-024 caller can represent them anyway.
+        let definition = create_repeatable_test_definition();
+        let parser = CliParser::new(&definition);
+
+        let args = vec![
+            "--output".to_string(),
+            "csv".to_string(),
+            "file=a.csv".to_string(),
+        ];
+        let result = parser.parse(&args).unwrap();
+
+        assert_eq!(result.get("output"), None);
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -187,6 +187,8 @@
 
 #[allow(unused_imports)]
 use crate::error::Result;
+use cli_parser::{OptionOccurrence, ParsedValue};
+use std::collections::HashMap;
 
 // Public submodules
 pub mod cli_parser;
@@ -196,6 +198,106 @@ pub mod type_parser;
 // Re-export commonly used types
 pub use cli_parser::CliParser;
 pub use repl_parser::{ParsedCommand, ReplParser};
+
+/// Parsed command arguments, passed to [`crate::executor::CommandHandler::execute`]
+/// and [`crate::executor::AsyncCommandHandler::execute`]
+///
+/// Wraps the output of [`CliParser::parse_typed`], exposing typed accessors
+/// so handlers never need to match on [`ParsedValue`] directly. Introduced
+/// in v0.6.0 (DD-024, #39) to replace `&HashMap<String, String>`, which
+/// could not represent repeatable options.
+///
+/// Lives directly in `parser` rather than nested under `cli_parser`: it is
+/// the shared type consumed by every handler regardless of dispatch path
+/// (CLI one-shot via [`CliParser::parse_typed`], or REPL via
+/// [`ParsedArgs::from_scalars`]) — not a CLI-specific detail.
+///
+/// # Example
+///
+/// ```
+/// use dynamic_cli::parser::ParsedArgs;
+///
+/// let args = ParsedArgs::from_scalars(
+///     [("name".to_string(), "World".to_string())].into_iter().collect(),
+/// );
+/// assert_eq!(args.get_scalar("name"), Some("World"));
+/// assert_eq!(args.get_scalar("missing"), None);
+/// ```
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct ParsedArgs(HashMap<String, ParsedValue>);
+
+impl ParsedArgs {
+    /// Wrap an already-typed result, as produced by [`CliParser::parse_typed`]
+    pub fn new(values: HashMap<String, ParsedValue>) -> Self {
+        Self(values)
+    }
+
+    /// Build a scalar-only `ParsedArgs` from a plain `HashMap<String, String>`
+    ///
+    /// Every entry becomes a [`ParsedValue::Scalar`]; there is no way to
+    /// represent [`ParsedValue::Repeated`] through this constructor.
+    ///
+    /// Used by the REPL dispatch path (`interface/repl.rs`), which relies
+    /// on [`crate::parser::repl_parser::ReplParser::parse_line`] — itself
+    /// untouched by DD-024, since repeatable options have no interactive
+    /// REPL-typing use case (see `DESIGN_DECISIONS.md`, DD-024 addendum,
+    /// 2026-07-24). Batch/scripted invocations are expected to go through
+    /// [`CliParser::parse_typed`] directly instead (see issue #41,
+    /// `ScriptLoaderPlugin`).
+    pub fn from_scalars(values: HashMap<String, String>) -> Self {
+        Self(
+            values
+                .into_iter()
+                .map(|(k, v)| (k, ParsedValue::Scalar(v)))
+                .collect(),
+        )
+    }
+
+    /// Get a scalar argument or option value by name
+    ///
+    /// Returns `None` both when the name is absent and when it is present
+    /// but holds a [`ParsedValue::Repeated`] value — mirroring
+    /// `HashMap::get`'s silent-on-absence semantics rather than
+    /// distinguishing "wrong kind" from "missing".
+    pub fn get_scalar(&self, name: &str) -> Option<&str> {
+        match self.0.get(name) {
+            Some(ParsedValue::Scalar(s)) => Some(s.as_str()),
+            _ => None,
+        }
+    }
+
+    /// Get every occurrence of a repeatable option by name
+    ///
+    /// Returns `None` both when the name is absent and when it is present
+    /// but holds a [`ParsedValue::Scalar`] value — same silent-on-absence
+    /// contract as [`Self::get_scalar`].
+    pub fn get_repeated(&self, name: &str) -> Option<&[OptionOccurrence]> {
+        match self.0.get(name) {
+            Some(ParsedValue::Repeated(occurrences)) => Some(occurrences.as_slice()),
+            _ => None,
+        }
+    }
+
+    /// Collapse back down to a scalar-only `HashMap<String, String>`
+    ///
+    /// Every [`ParsedValue::Scalar`] entry is kept as-is; any
+    /// [`ParsedValue::Repeated`] entry is silently dropped — mirroring the
+    /// same "no consumer yet" rationale as [`Self::from_scalars`] (see the
+    /// DD-024 addendum in `DESIGN_DECISIONS.md`). Used at the boundary of
+    /// subsystems that predate DD-024 and have not been extended to
+    /// understand repeatable options, e.g. the WASM plugin ABI
+    /// ([`crate::plugin::wasm::WasmHandler`]), which serializes arguments
+    /// as flat `HashMap<String, String>` to the guest.
+    pub fn to_scalar_map(&self) -> HashMap<String, String> {
+        self.0
+            .iter()
+            .filter_map(|(k, v)| match v {
+                ParsedValue::Scalar(s) => Some((k.clone(), s.clone())),
+                ParsedValue::Repeated(_) => None,
+            })
+            .collect()
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -212,11 +314,7 @@ mod tests {
     struct IntegrationTestHandler;
 
     impl CommandHandler for IntegrationTestHandler {
-        fn execute(
-            &self,
-            _context: &mut dyn ExecutionContext,
-            _args: &HashMap<String, String>,
-        ) -> Result<()> {
+        fn execute(&self, _context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
             Ok(())
         }
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -256,6 +256,8 @@ mod tests {
                     default: Some("false".to_string()),
                     description: "Enable verbose output".to_string(),
                     choices: vec![],
+                    repeatable: false,
+                    option_parameters: HashMap::new(),
                 },
                 OptionDefinition {
                     name: "iterations".to_string(),
@@ -266,6 +268,8 @@ mod tests {
                     default: Some("100".to_string()),
                     description: "Number of iterations".to_string(),
                     choices: vec![],
+                    repeatable: false,
+                    option_parameters: HashMap::new(),
                 },
                 OptionDefinition {
                     name: "threshold".to_string(),
@@ -276,6 +280,8 @@ mod tests {
                     default: Some("0.5".to_string()),
                     description: "Analysis threshold".to_string(),
                     choices: vec![],
+                    repeatable: false,
+                    option_parameters: HashMap::new(),
                 },
             ],
             implementation: "analyze_handler".to_string(),

--- a/src/parser/repl_parser.rs
+++ b/src/parser/repl_parser.rs
@@ -10,9 +10,8 @@
 //! use dynamic_cli::parser::repl_parser::ReplParser;
 //! use dynamic_cli::registry::CommandRegistry;
 //! use dynamic_cli::config::schema::{CommandDefinition, ArgumentType};
-//! use dynamic_cli::executor::CommandHandler;
+//! use dynamic_cli::executor::{CommandHandler, ParsedArgs};
 //! use dynamic_cli::context::ExecutionContext;
-//! use std::collections::HashMap;
 //!
 //! // Create registry
 //! let mut registry = CommandRegistry::new();
@@ -34,7 +33,7 @@
 //!     fn execute(
 //!         &self,
 //!         _context: &mut dyn ExecutionContext,
-//!         _args: &HashMap<String, String>,
+//!         _args: &ParsedArgs,
 //!     ) -> dynamic_cli::error::Result<()> {
 //!         Ok(())
 //!     }
@@ -347,7 +346,7 @@ mod tests {
         ArgumentDefinition, ArgumentType, CommandDefinition, OptionDefinition,
     };
     use crate::context::ExecutionContext;
-    use crate::executor::CommandHandler;
+    use crate::executor::{CommandHandler, ParsedArgs};
 
     // Dummy handler for tests
     struct TestHandler;
@@ -356,7 +355,7 @@ mod tests {
         fn execute(
             &self,
             _context: &mut dyn ExecutionContext,
-            _args: &HashMap<String, String>,
+            _args: &ParsedArgs,
         ) -> crate::error::Result<()> {
             Ok(())
         }

--- a/src/parser/repl_parser.rs
+++ b/src/parser/repl_parser.rs
@@ -389,6 +389,8 @@ mod tests {
                 default: Some("false".to_string()),
                 description: "Loud greeting".to_string(),
                 choices: vec![],
+                repeatable: false,
+                option_parameters: HashMap::new(),
             }],
             implementation: "hello_handler".to_string(),
         };
@@ -430,6 +432,8 @@ mod tests {
                 default: Some("false".to_string()),
                 description: "Verbose output".to_string(),
                 choices: vec![],
+                repeatable: false,
+                option_parameters: HashMap::new(),
             }],
             implementation: "process_handler".to_string(),
         };

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -25,8 +25,7 @@
 //!
 //! ```
 //! use dynamic_cli::plugin::{Plugin, SystemPlugin};
-//! use dynamic_cli::executor::CommandHandler;
-//! use std::collections::HashMap;
+//! use dynamic_cli::executor::{CommandHandler, ParsedArgs};
 //!
 //! // A minimal plugin supplying one handler
 //! struct GreetPlugin;
@@ -42,10 +41,9 @@
 //!             fn execute(
 //!                 &self,
 //!                 _ctx: &mut dyn dynamic_cli::context::ExecutionContext,
-//!                 args: &HashMap<String, String>,
+//!                 args: &ParsedArgs,
 //!             ) -> dynamic_cli::Result<()> {
-//!                 let default = "World".to_string();
-//!                 println!("Hello, {}!", args.get("name").unwrap_or(&default));
+//!                 println!("Hello, {}!", args.get_scalar("name").unwrap_or("World"));
 //!                 Ok(())
 //!             }
 //!         }
@@ -105,9 +103,8 @@ pub use system::SystemPlugin;
 ///
 /// ```
 /// use dynamic_cli::plugin::{Plugin, SystemPlugin};
-/// use dynamic_cli::executor::CommandHandler;
+/// use dynamic_cli::executor::{CommandHandler, ParsedArgs};
 /// use dynamic_cli::context::ExecutionContext;
-/// use std::collections::HashMap;
 ///
 /// struct MyPlugin;
 ///
@@ -122,7 +119,7 @@ pub use system::SystemPlugin;
 ///             fn execute(
 ///                 &self,
 ///                 _ctx: &mut dyn ExecutionContext,
-///                 _args: &HashMap<String, String>,
+///                 _args: &ParsedArgs,
 ///             ) -> dynamic_cli::Result<()> {
 ///                 println!("executed");
 ///                 Ok(())
@@ -164,6 +161,7 @@ pub trait Plugin: Send + Sync {
 mod tests {
     use super::*;
     use crate::context::ExecutionContext;
+    use crate::parser::ParsedArgs;
     use crate::Result;
     use std::any::Any;
     use std::collections::HashMap;
@@ -203,9 +201,9 @@ mod tests {
                 fn execute(
                     &self,
                     _ctx: &mut dyn ExecutionContext,
-                    args: &HashMap<String, String>,
+                    args: &ParsedArgs,
                 ) -> Result<()> {
-                    for (k, v) in args {
+                    for (k, v) in args.to_scalar_map() {
                         println!("{k}={v}");
                     }
                     Ok(())
@@ -231,11 +229,7 @@ mod tests {
         fn handlers(&self) -> Vec<(String, Box<dyn CommandHandler>)> {
             struct NoopHandler;
             impl CommandHandler for NoopHandler {
-                fn execute(
-                    &self,
-                    _: &mut dyn ExecutionContext,
-                    _: &HashMap<String, String>,
-                ) -> Result<()> {
+                fn execute(&self, _: &mut dyn ExecutionContext, _: &ParsedArgs) -> Result<()> {
                     Ok(())
                 }
             }
@@ -308,6 +302,7 @@ mod tests {
         let mut ctx = TestContext;
         let mut args = HashMap::new();
         args.insert("key".to_string(), "value".to_string());
+        let args = ParsedArgs::from_scalars(args);
         assert!(handler.execute(&mut ctx, &args).is_ok());
     }
 

--- a/src/plugin/system.rs
+++ b/src/plugin/system.rs
@@ -29,7 +29,7 @@ use std::sync::Arc;
 ///
 /// | Implementation name | Behaviour |
 /// |---------------------|-----------|
-/// | `system_help`       | Prints application or per-command help via the active [`HelpFormatter`][crate::help::HelpFormatter] |
+/// | `system_help`       | Prints application or per-command help via the active [`HelpFormatter`] |
 /// | `system_version`    | Prints the version from `metadata.version` in the config |
 /// | `system_exit`       | Runs the shutdown callback then exits (default: `std::process::exit(0)`) |
 ///

--- a/src/plugin/system.rs
+++ b/src/plugin/system.rs
@@ -10,9 +10,9 @@ use crate::config::schema::CommandsConfig;
 use crate::context::ExecutionContext;
 use crate::executor::CommandHandler;
 use crate::help::{DefaultHelpFormatter, HelpFormatter};
+use crate::parser::ParsedArgs;
 use crate::plugin::Plugin;
 use crate::Result;
-use std::collections::HashMap;
 use std::sync::Arc;
 
 // ============================================================================
@@ -241,16 +241,12 @@ struct SystemHelpHandler {
 }
 
 impl CommandHandler for SystemHelpHandler {
-    fn execute(
-        &self,
-        _ctx: &mut dyn ExecutionContext,
-        args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, _ctx: &mut dyn ExecutionContext, args: &ParsedArgs) -> Result<()> {
         let formatter = DefaultHelpFormatter::new();
 
         match self.config.as_ref() {
             Some(cfg) => {
-                if let Some(command) = args.get("command") {
+                if let Some(command) = args.get_scalar("command") {
                     print!("{}", formatter.format_command(cfg, command));
                 } else {
                     print!("{}", formatter.format_app(cfg));
@@ -270,11 +266,7 @@ struct SystemVersionHandler {
 }
 
 impl CommandHandler for SystemVersionHandler {
-    fn execute(
-        &self,
-        _ctx: &mut dyn ExecutionContext,
-        _args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, _ctx: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
         match self.config.as_ref() {
             Some(cfg) => println!("{}", cfg.metadata.version),
             None => println!("(version unknown)"),
@@ -293,11 +285,7 @@ struct SystemExitHandler {
 }
 
 impl CommandHandler for SystemExitHandler {
-    fn execute(
-        &self,
-        _ctx: &mut dyn ExecutionContext,
-        _args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, _ctx: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
         // Run the shutdown sequence supplied by the application.
         // The default implementation calls std::process::exit(0).
         (self.exit_fn)();
@@ -317,6 +305,7 @@ mod tests {
     use super::*;
     use crate::config::schema::{CommandsConfig, Metadata};
     use std::any::Any;
+    use std::collections::HashMap;
 
     // -------------------------------------------------------------------------
     // Test fixtures
@@ -395,7 +384,9 @@ mod tests {
             .unwrap();
         assert_eq!(name, "system_version");
         let mut ctx = TestContext;
-        assert!(handler.execute(&mut ctx, &HashMap::new()).is_ok());
+        assert!(handler
+            .execute(&mut ctx, &ParsedArgs::from_scalars(HashMap::new()))
+            .is_ok());
     }
 
     #[test]
@@ -406,7 +397,9 @@ mod tests {
             .find(|(n, _)| n == "system_version")
             .unwrap();
         let mut ctx = TestContext;
-        assert!(handler.execute(&mut ctx, &HashMap::new()).is_ok());
+        assert!(handler
+            .execute(&mut ctx, &ParsedArgs::from_scalars(HashMap::new()))
+            .is_ok());
     }
 
     #[test]
@@ -415,7 +408,9 @@ mod tests {
         let handlers = plugin.handlers();
         let (_, handler) = handlers.iter().find(|(n, _)| n == "system_help").unwrap();
         let mut ctx = TestContext;
-        assert!(handler.execute(&mut ctx, &HashMap::new()).is_ok());
+        assert!(handler
+            .execute(&mut ctx, &ParsedArgs::from_scalars(HashMap::new()))
+            .is_ok());
     }
 
     #[test]
@@ -426,6 +421,7 @@ mod tests {
         let mut ctx = TestContext;
         let mut args = HashMap::new();
         args.insert("command".to_string(), "nonexistent".to_string());
+        let args = ParsedArgs::from_scalars(args);
         assert!(handler.execute(&mut ctx, &args).is_ok());
     }
 
@@ -434,7 +430,9 @@ mod tests {
         let handlers = SystemPlugin::new().handlers();
         let (_, handler) = handlers.iter().find(|(n, _)| n == "system_help").unwrap();
         let mut ctx = TestContext;
-        assert!(handler.execute(&mut ctx, &HashMap::new()).is_ok());
+        assert!(handler
+            .execute(&mut ctx, &ParsedArgs::from_scalars(HashMap::new()))
+            .is_ok());
     }
 
     // -------------------------------------------------------------------------
@@ -467,7 +465,7 @@ mod tests {
         let (_, handler) = handlers.iter().find(|(n, _)| n == "system_exit").unwrap();
 
         let mut ctx = TestContext;
-        let result = handler.execute(&mut ctx, &HashMap::new());
+        let result = handler.execute(&mut ctx, &ParsedArgs::from_scalars(HashMap::new()));
 
         assert!(result.is_ok());
         assert!(
@@ -493,6 +491,7 @@ mod tests {
         let mut ctx = TestContext;
         let mut args = HashMap::new();
         args.insert("unexpected_arg".to_string(), "value".to_string());
+        let args = ParsedArgs::from_scalars(args);
 
         assert!(handler.execute(&mut ctx, &args).is_ok());
         assert!(called.load(Ordering::SeqCst));

--- a/src/plugin/wasm.rs
+++ b/src/plugin/wasm.rs
@@ -76,6 +76,7 @@
 use crate::context::ExecutionContext;
 use crate::error::WasmError;
 use crate::executor::CommandHandler;
+use crate::parser::ParsedArgs;
 use crate::plugin::Plugin;
 use crate::Result;
 use std::collections::HashMap;
@@ -447,14 +448,15 @@ impl WasmHandler {
 }
 
 impl CommandHandler for WasmHandler {
-    fn execute(
-        &self,
-        _ctx: &mut dyn ExecutionContext,
-        args: &HashMap<String, String>,
-    ) -> Result<()> {
+    fn execute(&self, _ctx: &mut dyn ExecutionContext, args: &ParsedArgs) -> Result<()> {
         // ExecutionContext is intentionally not forwarded to the guest —
         // see the module-level "Known limitation" section.
-        self.call_guest(args)
+        //
+        // The WASM ABI (DD-021) predates repeatable options (DD-024) and
+        // has not been extended to represent them across the host/guest
+        // boundary; any `ParsedValue::Repeated` entry is silently dropped
+        // by `to_scalar_map()`, same rationale as the REPL path.
+        self.call_guest(&args.to_scalar_map())
     }
 }
 
@@ -653,7 +655,7 @@ mod tests {
         let (_, handler) = &handlers[0];
 
         let mut ctx = TestContext;
-        let args = HashMap::new();
+        let args = ParsedArgs::from_scalars(HashMap::new());
         assert!(handler.execute(&mut ctx, &args).is_ok());
     }
 
@@ -669,6 +671,7 @@ mod tests {
         let mut args = HashMap::new();
         args.insert("name".to_string(), "World".to_string());
         args.insert("count".to_string(), "3".to_string());
+        let args = ParsedArgs::from_scalars(args);
         assert!(handler.execute(&mut ctx, &args).is_ok());
     }
 
@@ -685,7 +688,7 @@ mod tests {
 
         let mut ctx = TestContext;
         for _ in 0..50 {
-            let args = HashMap::new();
+            let args = ParsedArgs::from_scalars(HashMap::new());
             assert!(handler.execute(&mut ctx, &args).is_ok());
         }
     }
@@ -703,7 +706,7 @@ mod tests {
         let (_, handler) = &handlers[0];
 
         let mut ctx = TestContext;
-        let args = HashMap::new();
+        let args = ParsedArgs::from_scalars(HashMap::new());
         let result = handler.execute(&mut ctx, &args);
         assert!(result.is_err());
 
@@ -725,7 +728,7 @@ mod tests {
         let (_, handler) = &handlers[0];
 
         let mut ctx = TestContext;
-        let args = HashMap::new();
+        let args = ParsedArgs::from_scalars(HashMap::new());
         let result = handler.execute(&mut ctx, &args);
         assert!(result.is_err());
 
@@ -747,7 +750,7 @@ mod tests {
         let (_, handler) = &handlers[0];
 
         let mut ctx = TestContext;
-        let args = HashMap::new();
+        let args = ParsedArgs::from_scalars(HashMap::new());
         assert!(handler.execute(&mut ctx, &args).is_err());
     }
 

--- a/src/registry/command_registry.rs
+++ b/src/registry/command_registry.rs
@@ -16,8 +16,7 @@
 //! ```
 //! use dynamic_cli::registry::CommandRegistry;
 //! use dynamic_cli::config::schema::CommandDefinition;
-//! use dynamic_cli::executor::CommandHandler;
-//! use std::collections::HashMap;
+//! use dynamic_cli::executor::{CommandHandler, ParsedArgs};
 //!
 //! // Create a registry
 //! let mut registry = CommandRegistry::new();
@@ -39,7 +38,7 @@
 //!     fn execute(
 //!         &self,
 //!         _ctx: &mut dyn dynamic_cli::context::ExecutionContext,
-//!         _args: &HashMap<String, String>,
+//!         _args: &ParsedArgs,
 //!     ) -> dynamic_cli::Result<()> {
 //!         println!("Hello!");
 //!         Ok(())
@@ -106,7 +105,7 @@ enum StoredHandler {
 /// # };
 /// # struct TestCommand;
 /// # impl CommandHandler for TestCommand {
-/// #     fn execute(&self, _: &mut dyn dynamic_cli::context::ExecutionContext, _: &HashMap<String, String>) -> dynamic_cli::Result<()> { Ok(()) }
+/// #     fn execute(&self, _: &mut dyn dynamic_cli::context::ExecutionContext, _: &dynamic_cli::parser::ParsedArgs) -> dynamic_cli::Result<()> { Ok(()) }
 /// # }
 /// registry.register_sync(definition, Box::new(TestCommand))?;
 ///
@@ -224,8 +223,7 @@ impl CommandRegistry {
     /// ```
     /// use dynamic_cli::registry::CommandRegistry;
     /// use dynamic_cli::config::schema::CommandDefinition;
-    /// use dynamic_cli::executor::CommandHandler;
-    /// use std::collections::HashMap;
+    /// use dynamic_cli::executor::{CommandHandler, ParsedArgs};
     ///
     /// let mut registry = CommandRegistry::new();
     ///
@@ -244,7 +242,7 @@ impl CommandRegistry {
     ///     fn execute(
     ///         &self,
     ///         _: &mut dyn dynamic_cli::context::ExecutionContext,
-    ///         _: &HashMap<String, String>,
+    ///         _: &ParsedArgs,
     ///     ) -> dynamic_cli::Result<()> {
     ///         Ok(())
     ///     }
@@ -310,8 +308,7 @@ impl CommandRegistry {
     /// ```
     /// use dynamic_cli::registry::CommandRegistry;
     /// use dynamic_cli::config::schema::CommandDefinition;
-    /// use dynamic_cli::executor::AsyncCommandHandler;
-    /// use std::collections::HashMap;
+    /// use dynamic_cli::executor::{AsyncCommandHandler, ParsedArgs};
     /// use async_trait::async_trait;
     ///
     /// let mut registry = CommandRegistry::new();
@@ -332,7 +329,7 @@ impl CommandRegistry {
     ///     async fn execute(
     ///         &self,
     ///         _: &mut dyn dynamic_cli::context::ExecutionContext,
-    ///         _: &HashMap<String, String>,
+    ///         _: &ParsedArgs,
     ///     ) -> dynamic_cli::Result<()> {
     ///         Ok(())
     ///     }
@@ -395,7 +392,7 @@ impl CommandRegistry {
     /// # };
     /// # struct TestCmd;
     /// # impl CommandHandler for TestCmd {
-    /// #     fn execute(&self, _: &mut dyn dynamic_cli::context::ExecutionContext, _: &HashMap<String, String>) -> dynamic_cli::Result<()> { Ok(()) }
+    /// #     fn execute(&self, _: &mut dyn dynamic_cli::context::ExecutionContext, _: &dynamic_cli::parser::ParsedArgs) -> dynamic_cli::Result<()> { Ok(()) }
     /// # }
     /// # registry.register_sync(definition, Box::new(TestCmd)).unwrap();
     /// // Resolve command name
@@ -448,7 +445,7 @@ impl CommandRegistry {
     /// # };
     /// # struct TestCmd;
     /// # impl CommandHandler for TestCmd {
-    /// #     fn execute(&self, _: &mut dyn dynamic_cli::context::ExecutionContext, _: &HashMap<String, String>) -> dynamic_cli::Result<()> { Ok(()) }
+    /// #     fn execute(&self, _: &mut dyn dynamic_cli::context::ExecutionContext, _: &dynamic_cli::parser::ParsedArgs) -> dynamic_cli::Result<()> { Ok(()) }
     /// # }
     /// # registry.register_sync(definition, Box::new(TestCmd)).unwrap();
     /// // Get by name
@@ -507,7 +504,7 @@ impl CommandRegistry {
     /// # };
     /// # struct ExecCmd;
     /// # impl CommandHandler for ExecCmd {
-    /// #     fn execute(&self, _: &mut dyn dynamic_cli::context::ExecutionContext, _: &HashMap<String, String>) -> dynamic_cli::Result<()> { Ok(()) }
+    /// #     fn execute(&self, _: &mut dyn dynamic_cli::context::ExecutionContext, _: &dynamic_cli::parser::ParsedArgs) -> dynamic_cli::Result<()> { Ok(()) }
     /// # }
     /// # registry.register_sync(definition, Box::new(ExecCmd)).unwrap();
     /// // Get handler by name
@@ -569,7 +566,7 @@ impl CommandRegistry {
     /// # struct FetchCmd;
     /// # #[async_trait]
     /// # impl AsyncCommandHandler for FetchCmd {
-    /// #     async fn execute(&self, _: &mut dyn dynamic_cli::context::ExecutionContext, _: &HashMap<String, String>) -> dynamic_cli::Result<()> { Ok(()) }
+    /// #     async fn execute(&self, _: &mut dyn dynamic_cli::context::ExecutionContext, _: &dynamic_cli::parser::ParsedArgs) -> dynamic_cli::Result<()> { Ok(()) }
     /// # }
     /// # registry.register_async(definition, Box::new(FetchCmd)).unwrap();
     /// assert!(registry.get_handler_async("fetch").is_some());
@@ -620,7 +617,7 @@ impl CommandRegistry {
     /// # };
     /// # struct TestCmd;
     /// # impl CommandHandler for TestCmd {
-    /// #     fn execute(&self, _: &mut dyn dynamic_cli::context::ExecutionContext, _: &HashMap<String, String>) -> dynamic_cli::Result<()> { Ok(()) }
+    /// #     fn execute(&self, _: &mut dyn dynamic_cli::context::ExecutionContext, _: &dynamic_cli::parser::ParsedArgs) -> dynamic_cli::Result<()> { Ok(()) }
     /// # }
     /// # registry.register_sync(def1, Box::new(TestCmd)).unwrap();
     /// # registry.register_sync(def2, Box::new(TestCmd)).unwrap();
@@ -685,7 +682,7 @@ impl CommandRegistry {
     /// # };
     /// # struct TestCmd;
     /// # impl CommandHandler for TestCmd {
-    /// #     fn execute(&self, _: &mut dyn dynamic_cli::context::ExecutionContext, _: &HashMap<String, String>) -> dynamic_cli::Result<()> { Ok(()) }
+    /// #     fn execute(&self, _: &mut dyn dynamic_cli::context::ExecutionContext, _: &dynamic_cli::parser::ParsedArgs) -> dynamic_cli::Result<()> { Ok(()) }
     /// # }
     /// # registry.register_sync(definition, Box::new(TestCmd)).unwrap();
     /// assert!(registry.contains("test"));
@@ -707,6 +704,7 @@ impl Default for CommandRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parser::ParsedArgs;
     use std::any::Any;
 
     // Test fixtures
@@ -728,7 +726,7 @@ mod tests {
         fn execute(
             &self,
             _context: &mut dyn crate::context::ExecutionContext,
-            _args: &HashMap<String, String>,
+            _args: &ParsedArgs,
         ) -> crate::error::Result<()> {
             Ok(())
         }
@@ -741,7 +739,7 @@ mod tests {
         async fn execute(
             &self,
             _context: &mut dyn crate::context::ExecutionContext,
-            _args: &HashMap<String, String>,
+            _args: &ParsedArgs,
         ) -> crate::error::Result<()> {
             Ok(())
         }

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -48,8 +48,7 @@
 //! ```
 //! use dynamic_cli::registry::CommandRegistry;
 //! use dynamic_cli::config::schema::CommandDefinition;
-//! use dynamic_cli::executor::CommandHandler;
-//! use std::collections::HashMap;
+//! use dynamic_cli::executor::{CommandHandler, ParsedArgs};
 //!
 //! // 1. Create a registry
 //! let mut registry = CommandRegistry::new();
@@ -71,10 +70,9 @@
 //!     fn execute(
 //!         &self,
 //!         _ctx: &mut dyn dynamic_cli::context::ExecutionContext,
-//!         args: &HashMap<String, String>,
+//!         args: &ParsedArgs,
 //!     ) -> dynamic_cli::Result<()> {
-//!         let default_world = "World".to_string();
-//!         let name = args.get("name").unwrap_or(&default_world);
+//!         let name = args.get_scalar("name").unwrap_or("World");
 //!         println!("Hello, {}!", name);
 //!         Ok(())
 //!     }
@@ -103,7 +101,6 @@
 //! use dynamic_cli::registry::CommandRegistry;
 //! # use dynamic_cli::config::schema::CommandDefinition;
 //! # use dynamic_cli::executor::CommandHandler;
-//! # use std::collections::HashMap;
 //!
 //! let mut registry = CommandRegistry::new();
 //!
@@ -118,7 +115,7 @@
 //! # };
 //! # struct TestCmd;
 //! # impl CommandHandler for TestCmd {
-//! #     fn execute(&self, _: &mut dyn dynamic_cli::context::ExecutionContext, _: &HashMap<String, String>) -> dynamic_cli::Result<()> { Ok(()) }
+//! #     fn execute(&self, _: &mut dyn dynamic_cli::context::ExecutionContext, _: &dynamic_cli::parser::ParsedArgs) -> dynamic_cli::Result<()> { Ok(()) }
 //! # }
 //! registry.register_sync(definition, Box::new(TestCmd))?;
 //! # Ok::<(), dynamic_cli::error::DynamicCliError>(())
@@ -130,7 +127,6 @@
 //! # use dynamic_cli::registry::CommandRegistry;
 //! # use dynamic_cli::config::schema::CommandDefinition;
 //! # use dynamic_cli::executor::CommandHandler;
-//! # use std::collections::HashMap;
 //! # let mut registry = CommandRegistry::new();
 //! let definition = CommandDefinition {
 //!     name: "simulate".to_string(),
@@ -148,7 +144,7 @@
 //!
 //! # struct SimCmd;
 //! # impl CommandHandler for SimCmd {
-//! #     fn execute(&self, _: &mut dyn dynamic_cli::context::ExecutionContext, _: &HashMap<String, String>) -> dynamic_cli::Result<()> { Ok(()) }
+//! #     fn execute(&self, _: &mut dyn dynamic_cli::context::ExecutionContext, _: &dynamic_cli::parser::ParsedArgs) -> dynamic_cli::Result<()> { Ok(()) }
 //! # }
 //! registry.register_sync(definition, Box::new(SimCmd))?;
 //!
@@ -166,7 +162,6 @@
 //! # use dynamic_cli::registry::CommandRegistry;
 //! # use dynamic_cli::config::schema::CommandDefinition;
 //! # use dynamic_cli::executor::CommandHandler;
-//! # use std::collections::HashMap;
 //! # let mut registry = CommandRegistry::new();
 //! # let def1 = CommandDefinition {
 //! #     name: "cmd1".to_string(),
@@ -188,7 +183,7 @@
 //! # };
 //! # struct TestCmd;
 //! # impl CommandHandler for TestCmd {
-//! #     fn execute(&self, _: &mut dyn dynamic_cli::context::ExecutionContext, _: &HashMap<String, String>) -> dynamic_cli::Result<()> { Ok(()) }
+//! #     fn execute(&self, _: &mut dyn dynamic_cli::context::ExecutionContext, _: &dynamic_cli::parser::ParsedArgs) -> dynamic_cli::Result<()> { Ok(()) }
 //! # }
 //! # registry.register_sync(def1, Box::new(TestCmd)).unwrap();
 //! # registry.register_sync(def2, Box::new(TestCmd)).unwrap();
@@ -205,7 +200,6 @@
 //! # use dynamic_cli::config::schema::CommandDefinition;
 //! # use dynamic_cli::executor::CommandHandler;
 //! # use dynamic_cli::error::{DynamicCliError, RegistryError};
-//! # use std::collections::HashMap;
 //! # let mut registry = CommandRegistry::new();
 //! # let def1 = CommandDefinition {
 //! #     name: "test".to_string(),
@@ -227,7 +221,7 @@
 //! # };
 //! # struct TestCmd;
 //! # impl CommandHandler for TestCmd {
-//! #     fn execute(&self, _: &mut dyn dynamic_cli::context::ExecutionContext, _: &HashMap<String, String>) -> dynamic_cli::Result<()> { Ok(()) }
+//! #     fn execute(&self, _: &mut dyn dynamic_cli::context::ExecutionContext, _: &dynamic_cli::parser::ParsedArgs) -> dynamic_cli::Result<()> { Ok(()) }
 //! # }
 //! # registry.register_sync(def1, Box::new(TestCmd)).unwrap();
 //! // Try to register duplicate
@@ -271,7 +265,7 @@
 //!     registry: &CommandRegistry,
 //!     command_name: &str,
 //!     context: &mut dyn ExecutionContext,
-//!     args: &HashMap<String, String>,
+//!     args: &ParsedArgs,
 //! ) -> Result<()> {
 //!     let handler = registry.get_handler_sync(command_name)
 //!         .ok_or_else(|| anyhow::anyhow!("Unknown command"))?;
@@ -315,6 +309,7 @@ mod tests {
     use crate::config::schema::CommandDefinition;
     use crate::context::ExecutionContext;
     use crate::executor::CommandHandler;
+    use crate::parser::ParsedArgs;
     use std::any::Any;
     use std::collections::HashMap;
 
@@ -337,7 +332,7 @@ mod tests {
         fn execute(
             &self,
             _context: &mut dyn ExecutionContext,
-            _args: &HashMap<String, String>,
+            _args: &ParsedArgs,
         ) -> crate::error::Result<()> {
             Ok(())
         }
@@ -433,7 +428,7 @@ mod tests {
         if let Some(canonical_name) = registry.resolve_name(user_input) {
             if let Some(handler) = registry.get_handler_sync(canonical_name) {
                 let mut context = TestContext;
-                let args = HashMap::new();
+                let args = ParsedArgs::from_scalars(HashMap::new());
 
                 // Execute would happen here
                 let result = handler.execute(&mut context, &args);

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -20,7 +20,7 @@
 //!     ↓
 //! ValidationRule definitions
 //!     ↓
-//! Parsed arguments (HashMap<String, String>)
+//! Parsed arguments (ParsedArgs — scalar and repeatable values)
 //!     ↓
 //! Validators (this module)
 //!     ↓

--- a/tests/integration/async_token_test.rs
+++ b/tests/integration/async_token_test.rs
@@ -21,7 +21,6 @@ use dynamic_cli::config::schema::{CommandDefinition, Metadata};
 use dynamic_cli::executor::AsyncCommandHandler;
 use dynamic_cli::prelude::*;
 use std::any::Any;
-use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -66,7 +65,7 @@ impl AsyncCommandHandler for TokenFetchHandler {
     async fn execute(
         &self,
         _ctx: &mut dyn ExecutionContext,
-        _args: &HashMap<String, String>,
+        _args: &ParsedArgs,
     ) -> dynamic_cli::Result<()> {
         futures_timer::Delay::new(self.delay).await;
         self.tokens.lock().unwrap().push("tok_9f3a2b1c".to_string());

--- a/tests/integration/system_plugin_test.rs
+++ b/tests/integration/system_plugin_test.rs
@@ -15,7 +15,6 @@ use dynamic_cli::config::schema::{CommandDefinition, Metadata};
 use dynamic_cli::plugin::SystemPlugin;
 use dynamic_cli::prelude::*;
 use std::any::Any;
-use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 // ============================================================================
@@ -52,12 +51,9 @@ impl CommandHandler for GreetHandler {
     fn execute(
         &self,
         _ctx: &mut dyn ExecutionContext,
-        args: &HashMap<String, String>,
+        args: &ParsedArgs,
     ) -> dynamic_cli::Result<()> {
-        let name = args
-            .get("name")
-            .cloned()
-            .unwrap_or_else(|| "World".to_string());
+        let name = args.get_scalar("name").unwrap_or("World").to_string();
         self.greeted.lock().unwrap().push(name);
         Ok(())
     }

--- a/tests/integration/wasm_plugin_test.rs
+++ b/tests/integration/wasm_plugin_test.rs
@@ -24,7 +24,6 @@ use dynamic_cli::config::schema::{CommandDefinition, Metadata};
 use dynamic_cli::error::{DynamicCliError, WasmError};
 use dynamic_cli::prelude::*;
 use std::any::Any;
-use std::collections::HashMap;
 use std::io::Write;
 use tempfile::NamedTempFile;
 
@@ -52,7 +51,7 @@ impl CommandHandler for NativeHandler {
     fn execute(
         &self,
         _ctx: &mut dyn ExecutionContext,
-        _args: &HashMap<String, String>,
+        _args: &ParsedArgs,
     ) -> dynamic_cli::Result<()> {
         Ok(())
     }


### PR DESCRIPTION
## Summary

Integration PR for the full v0.6.0 cycle — DD-024 (repeatable options with typed sub-parameters) — merging `update/0.6.0` into `staging/0.6.0` for final verification before the release PR to `main`. Confirms code and documentation land coherently together, not as independently-reviewed pieces.

## What this branch contains

### Code (#35–#39)
- `OptionDefinition::repeatable` + `option_parameters` (schema).
- Config-load-time validation of repeatable-option consistency (`validate_options()`).
- Four new `ParseError` variants: `UnknownOptionParameter`, `MissingRequiredOptionParameter`, `UnknownDiscriminant`,
  `DuplicateOptionOccurrence`.
- Parser support: `OptionOccurrence`, `ParsedValue::{Scalar, Repeated}`.
- **Breaking**: `CommandHandler`/`AsyncCommandHandler` `execute()` and `validate()` take `&ParsedArgs` instead of `&HashMap<String, String>`.

### Docs (#40)
- CHANGELOG.md — real v0.6.0 entry, breaking-change migration snippet.
- CONFIG_SYNTAX_REFERENCE.md / .fr.md — "Repeatable Options" section.
- README.md / .fr.md — install version, quick-start example migrated.
- DESIGN_DECISIONS.md — DD-024 marked closed.

## Verification checklist

- [x] `cargo test --all-features` green on the merged branch
- [x] `cargo clippy --all-features -- -D warnings` clean
- [x] `cargo test --doc` — doc examples compile against the new signature (README/CONFIG_SYNTAX_REFERENCE snippets included)
- [x] `cargo llvm-cov --all-targets --workspace` ≥ 85%
- [x] Documented behaviour (CONFIG_SYNTAX_REFERENCE, CHANGELOG) matches actual validator/parser behaviour — no drift between #35–#39 and #40
- [x] No leftover references to the old `HashMap<String, String>` signature in examples/, README, or rustdoc

## Not in scope here

- `Cargo.toml` version bump — next commit on `staging/0.6.0`, once this merges (pre-release checklist step).
- Issue/milestone tracker sync (`dcli-issues.yml`) — separate pass.

Refs #21, #35, #36, #37, #38, #39, #40