### PR TITLE
v0.7.0 — Static Plugin Library: granular plugins, batch execution, advanced RPN example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.97.0
+        with:
+          components: rustfmt
+
       - name: Cache Cargo registry
         uses: actions/cache@v5
         with:
@@ -38,6 +43,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.97.0
+        with:
+          components: clippy
+
       - name: Cache Cargo registry
         uses: actions/cache@v5
         with:
@@ -54,6 +64,9 @@ jobs:
       - name: cargo clippy — feature wasm-plugins
         run: cargo clippy --features wasm-plugins -- -D warnings
 
+      - name: cargo clippy — all features (combined)
+        run: cargo clippy --all-features -- -D warnings
+
       # v0.5.0+ — activate when async feature flag is declared in Cargo.toml
       # - name: cargo clippy — feature async
       #   run: cargo clippy --features async -- -D warnings
@@ -67,6 +80,9 @@ jobs:
     needs: fmt
     steps:
       - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.97.0
 
       - name: Cache Cargo registry
         uses: actions/cache@v5
@@ -107,6 +123,9 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.97.0
 
       - name: Cache Cargo registry
         uses: actions/cache@v5

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ exclude = [
 
 [features]
 wasm-plugins = ["dep:wasmtime"]
+sysinfo-plugin = []
+env-plugin = []
+config-plugin = []
 
 [dependencies]
 # Asynchronus and I/O commands
@@ -92,10 +95,30 @@ path = "tests/integration/async_token_test.rs"
 # required-features = []
 
 # Example configuration (uncomment when examples are implemented)
-# [[example]]
-# name = "simple_calculator"
-# path = "examples/simple_calculator.rs"
-# required-features = []
+[[example]]
+name = "simple_calculator"
+path = "examples/simple_calculator.rs"
+required-features = []
+
+[[example]]
+name = "rpn_calculator"
+path = "examples/rpn_calculator.rs"
+required-features = []
+
+[[example]]
+name = "file_manager"
+path = "examples/file_manager.rs"
+required-features = []
+
+[[example]]
+name = "advanced_rpn_calculator"
+path = "examples/advanced_rpn_calculator.rs"
+required-features = ["sysinfo-plugin", "config-plugin"]
+
+[[example]]
+name = "task_runner"
+path = "examples/task_runner.rs"
+required-features = []
 
 # Configuration for documentation generation
 [package.metadata.docs.rs]

--- a/examples/advanced_rpn_calculator.rs
+++ b/examples/advanced_rpn_calculator.rs
@@ -1,0 +1,796 @@
+//! # Advanced RPN calculator example
+//!
+//! An HP-41CX-flavored extension of the `rpn_calculator` example,
+//! demonstrating more of `dynamic-cli`'s surface at once:
+//!
+//! ## Features (beyond the simple example)
+//!
+//! - Scientific functions: `sqrt`, `sq`, `inv`, `pow`, `exp`, `log10`,
+//!   `sin`, `cos`, `tan`, `chs`, `pi`
+//! - A 10-slot memory register bank (`sto`/`rcl`), à la HP-41 — simplified
+//!   from the real HP-41CX's 100+ registers
+//! - [`SysInfoPlugin`] and [`ConfigPlugin`] registered via
+//!   [`CliBuilder::register_plugin`], both feature-gated
+//! - Batch execution via [`CliApp::run_script`] (`--script <file>`)
+//! - Loading a script from an already-running REPL session via `:load
+//!   <file>` — nothing to wire up, this comes for free from
+//!   `ReplInterface`
+//!
+//! ## Usage
+//!
+//! ```bash
+//! # REPL mode (interactive)
+//! cargo run --example advanced_rpn_calculator --features sysinfo-plugin,config-plugin
+//!
+//! # CLI mode (single command)
+//! cargo run --example advanced_rpn_calculator --features sysinfo-plugin,config-plugin -- push 5
+//! cargo run --example advanced_rpn_calculator --features sysinfo-plugin,config-plugin -- push 4
+//! cargo run --example advanced_rpn_calculator --features sysinfo-plugin,config-plugin -- add
+//!
+//! # Batch mode — run a whole script of commands, one per line
+//! cargo run --example advanced_rpn_calculator --features sysinfo-plugin,config-plugin -- \
+//!     --script examples/configs/advanced_rpn_demo.txt
+//!
+//! # From inside the REPL, load the same script mid-session:
+//! #   arpn > :load examples/configs/advanced_rpn_demo.txt
+//! ```
+//!
+//! ## RPN Basics
+//!
+//! Reverse Polish Notation is a postfix notation in which operators follow
+//! their operands.
+//!
+//! ```text
+//! Infix : 3 + 4
+//! RPN   : 3 4 +
+//!
+//! Infix : (3 + 4) * 5
+//! RPN   : 3 4 + 5 *
+//! ```
+
+use dynamic_cli::error::{ExecutionError, ParseError};
+use dynamic_cli::prelude::*;
+use std::any::Any;
+use std::f64::consts::PI;
+
+// ================================================================================================
+// Execution context
+// ================================================================================================
+
+// Number of memory registers in the bank (HP-41-style sto/rcl, simplified
+// from the real HP-41CX's 100+ registers down to a fixed, easy-to-scan 10).
+const REGISTER_COUNT: usize = 10;
+
+/// Execution context for the advanced RPN calculator.
+///
+/// Extends the simple example's stack + last-x register with a small
+/// fixed-size memory bank, addressed by `sto <n>` / `rcl <n>` (`n` in
+/// `0..REGISTER_COUNT`).
+struct AdvancedRpnContext {
+    /// Calculation stack: top of the stack is the last element pushed.
+    stack: Vec<f64>,
+    /// Last x is the register containing the last value pushed via `push`.
+    last_x: f64,
+    /// Memory registers, indexed `0..REGISTER_COUNT`.
+    registers: [f64; REGISTER_COUNT],
+}
+
+impl Default for AdvancedRpnContext {
+    fn default() -> Self {
+        Self {
+            stack: Vec::new(),
+            last_x: 0.0,
+            registers: [0.0; REGISTER_COUNT],
+        }
+    }
+}
+
+impl AdvancedRpnContext {
+    /// Push a value onto the stack.
+    fn push(&mut self, value: f64) {
+        self.stack.push(value);
+        println!("  → Pushed {:?}", self.stack.last());
+    }
+
+    /// Push a value onto the stack and the last-x register.
+    fn push_x(&mut self, value: f64) {
+        self.last_x = value;
+        self.push(value);
+    }
+
+    /// Pop a value from the stack.
+    fn pop(&mut self) -> Result<f64> {
+        self.stack.pop().ok_or_else(|| {
+            DynamicCliError::Execution(ExecutionError::CommandFailed(anyhow::anyhow!(
+                "Stack is empty"
+            )))
+        })
+    }
+
+    /// Show the last-x register.
+    fn last_x(&self) -> f64 {
+        self.last_x
+    }
+
+    /// Swap the top two elements of the stack.
+    fn swap(&mut self) {
+        if self.stack.len() < 2 {
+            println!("  → Not enough elements on stack to swap");
+            return;
+        }
+
+        let x = self.stack.pop().unwrap();
+        let y = self.stack.pop().unwrap();
+
+        self.stack.push(x);
+        self.stack.push(y);
+
+        println!("  → Swapped the top two elements");
+    }
+
+    /// Peek at the top of the stack without removing it.
+    fn peek(&self) -> Option<f64> {
+        self.stack.last().copied()
+    }
+
+    /// Clear the stack (registers and last-x are untouched — mirrors the
+    /// simple example's `clear`, scoped to the stack only).
+    fn clear(&mut self) {
+        self.stack.clear();
+        println!("  → Stack cleared");
+    }
+
+    /// Display the stack content.
+    fn display(&self) {
+        if self.stack.is_empty() {
+            println!("    Stack is empty");
+        } else {
+            println!("  Stack: {:?}", self.stack);
+            println!("  Last X: {}", self.last_x);
+        }
+    }
+
+    /// Store the top of the stack into register `index`, without popping
+    /// it — matches the real HP-41's `STO` behaviour.
+    fn store(&mut self, index: usize) -> Result<()> {
+        let value = *self.stack.last().ok_or_else(|| {
+            DynamicCliError::Execution(ExecutionError::CommandFailed(anyhow::anyhow!(
+                "Stack is empty — nothing to store"
+            )))
+        })?;
+        self.registers[index] = value;
+        println!("  → Stored {} into register {}", value, index);
+        Ok(())
+    }
+
+    /// Push the value stored in register `index` onto the stack.
+    fn recall(&mut self, index: usize) {
+        let value = self.registers[index];
+        self.push_x(value);
+        println!("  → Recalled register {}: {}", index, value);
+    }
+
+    fn binary_op<F>(&mut self, operation: F, operator_name: &str) -> Result<()>
+    where
+        F: FnOnce(f64, f64) -> f64,
+    {
+        let x = self.pop()?;
+        let y = self.pop()?;
+        let result = operation(x, y);
+        self.push(result);
+        println!("  → {} {} {} = {}", y, x, operator_name, result);
+        Ok(())
+    }
+
+    fn single_op<F>(&mut self, operation: F, operator_name: &str) -> Result<()>
+    where
+        F: FnOnce(f64) -> f64,
+    {
+        let x = self.pop()?;
+        let result = operation(x);
+        self.push(result);
+        println!("  → {} {} = {}", operator_name, x, result);
+        Ok(())
+    }
+}
+
+impl ExecutionContext for AdvancedRpnContext {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+/// Downcast the context, or return the same `ContextDowncastFailed` error
+/// every handler below would otherwise repeat verbatim.
+fn downcast(context: &mut dyn ExecutionContext) -> Result<&mut AdvancedRpnContext> {
+    downcast_mut::<AdvancedRpnContext>(context).ok_or_else(|| {
+        DynamicCliError::Execution(ExecutionError::ContextDowncastFailed {
+            expected_type: "Advanced RPN Calculator context".to_string(),
+            suggestion: None,
+        })
+    })
+}
+
+/// Read and bounds-check a `register` argument (`0..REGISTER_COUNT`).
+///
+/// `ArgumentDefinition.validation` (the YAML `min`/`max` on `sto`/`rcl`)
+/// is descriptive only — the parser does not enforce it automatically —
+/// so the handler re-validates via [`validate_range`], the same free
+/// function the framework exposes for exactly this purpose.
+fn parse_register_index(args: &ParsedArgs) -> Result<usize> {
+    let raw = args.get_scalar("register").ok_or_else(|| {
+        DynamicCliError::Parse(ParseError::MissingArgument {
+            argument: "register".to_string(),
+            command: "sto/rcl".to_string(),
+            suggestion: None,
+        })
+    })?;
+
+    let index: i64 = raw.parse().map_err(|_| {
+        DynamicCliError::Parse(ParseError::TypeParseError {
+            arg_name: "register".to_string(),
+            expected_type: "integer".to_string(),
+            value: raw.to_string(),
+            details: Some("not a valid integer".to_string()),
+        })
+    })?;
+
+    validate_range(
+        index as f64,
+        "register",
+        Some(0.0),
+        Some((REGISTER_COUNT - 1) as f64),
+    )?;
+
+    Ok(index as usize)
+}
+
+// ================================================================================================
+// Command handlers — stack manipulation (unchanged from the simple example)
+// ================================================================================================
+
+// Handler for push command — push a number onto the stack.
+struct PushCommand;
+
+impl CommandHandler for PushCommand {
+    fn execute(&self, context: &mut dyn ExecutionContext, args: &ParsedArgs) -> Result<()> {
+        let rpn_context = downcast(context)?;
+
+        let cli_value = args.get_scalar("value").ok_or_else(|| {
+            DynamicCliError::Parse(ParseError::MissingArgument {
+                argument: "value".to_string(),
+                command: "push".to_string(),
+                suggestion: None,
+            })
+        })?;
+
+        let value = cli_value.parse::<f64>().map_err(|_| {
+            DynamicCliError::Parse(ParseError::TypeParseError {
+                arg_name: "value".to_string(),
+                expected_type: "float".to_string(),
+                value: cli_value.to_string(),
+                details: Some("not a valid number".to_string()),
+            })
+        })?;
+
+        rpn_context.push_x(value);
+        rpn_context.display();
+        Ok(())
+    }
+}
+
+// Handler for pop command — remove and display the top value.
+struct PopCommand;
+
+impl CommandHandler for PopCommand {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
+        let rpn_ctx = downcast(context)?;
+        let value = rpn_ctx.pop();
+        println!("  → Popped {:?}", value);
+        rpn_ctx.display();
+        Ok(())
+    }
+}
+
+// Handler for lastx command.
+struct LastXCommand;
+
+impl CommandHandler for LastXCommand {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
+        let rpn_ctx = downcast(context)?;
+        println!("  → LastX {:?}", rpn_ctx.last_x());
+        rpn_ctx.display();
+        Ok(())
+    }
+}
+
+// Handler for swap command.
+struct SwapCommand;
+
+impl CommandHandler for SwapCommand {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
+        let rpn_ctx = downcast(context)?;
+        rpn_ctx.swap();
+        rpn_ctx.display();
+        Ok(())
+    }
+}
+
+// Handler for peek command.
+struct PeekCommand;
+
+impl CommandHandler for PeekCommand {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
+        let rpn_ctx = downcast(context)?;
+        println!("  → Peek {:?}", rpn_ctx.peek());
+        Ok(())
+    }
+}
+
+// Handler for show command.
+struct ShowCommand;
+
+impl CommandHandler for ShowCommand {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
+        let rpn_ctx = downcast(context)?;
+        rpn_ctx.display();
+        Ok(())
+    }
+}
+
+// Handler for clear command.
+struct ClearCommand;
+
+impl CommandHandler for ClearCommand {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
+        let rpn_ctx = downcast(context)?;
+        rpn_ctx.clear();
+        Ok(())
+    }
+}
+
+// ================================================================================================
+// Command handlers — arithmetic and scientific functions
+// ================================================================================================
+
+// Handler for add function — pops two values, pushes their sum.
+struct AddCommand;
+
+impl CommandHandler for AddCommand {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
+        downcast(context)?.binary_op(|a, b| a + b, "+")
+    }
+}
+
+// Handler for sub function — pops two values, pushes their difference.
+struct SubCommand;
+
+impl CommandHandler for SubCommand {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
+        downcast(context)?.binary_op(|a, b| b - a, "-")
+    }
+}
+
+// Handler for mul function — pops two values, pushes their product.
+struct MulCommand;
+
+impl CommandHandler for MulCommand {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
+        downcast(context)?.binary_op(|a, b| a * b, "*")
+    }
+}
+
+// Handler for div function — pops two values, pushes their quotient.
+struct DivCommand;
+
+impl CommandHandler for DivCommand {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
+        downcast(context)?.binary_op(|a, b| b / a, "/")
+    }
+}
+
+// Handler for pow function — pops (y, x), pushes y raised to the power x.
+struct PowCommand;
+
+impl CommandHandler for PowCommand {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
+        downcast(context)?.binary_op(|x, y| y.powf(x), "^")
+    }
+}
+
+// Handler for ln function — natural logarithm.
+struct LnCommand;
+
+impl CommandHandler for LnCommand {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
+        downcast(context)?.single_op(|a| a.ln(), "ln")
+    }
+}
+
+// Handler for log10 function — base-10 logarithm.
+struct Log10Command;
+
+impl CommandHandler for Log10Command {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
+        downcast(context)?.single_op(|a| a.log10(), "log10")
+    }
+}
+
+// Handler for exp function — natural exponential.
+struct ExpCommand;
+
+impl CommandHandler for ExpCommand {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
+        downcast(context)?.single_op(|a| a.exp(), "exp")
+    }
+}
+
+// Handler for sqrt function — square root.
+struct SqrtCommand;
+
+impl CommandHandler for SqrtCommand {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
+        downcast(context)?.single_op(|a| a.sqrt(), "sqrt")
+    }
+}
+
+// Handler for sq function — square (x^2).
+struct SqCommand;
+
+impl CommandHandler for SqCommand {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
+        downcast(context)?.single_op(|a| a * a, "sq")
+    }
+}
+
+// Handler for inv function — reciprocal (1/x).
+struct InvCommand;
+
+impl CommandHandler for InvCommand {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
+        downcast(context)?.single_op(|a| 1.0 / a, "inv")
+    }
+}
+
+// Handler for chs function — change sign.
+struct ChsCommand;
+
+impl CommandHandler for ChsCommand {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
+        downcast(context)?.single_op(|a| -a, "chs")
+    }
+}
+
+// Handler for sin function — sine (radians).
+struct SinCommand;
+
+impl CommandHandler for SinCommand {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
+        downcast(context)?.single_op(|a| a.sin(), "sin")
+    }
+}
+
+// Handler for cos function — cosine (radians).
+struct CosCommand;
+
+impl CommandHandler for CosCommand {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
+        downcast(context)?.single_op(|a| a.cos(), "cos")
+    }
+}
+
+// Handler for tan function — tangent (radians).
+struct TanCommand;
+
+impl CommandHandler for TanCommand {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
+        downcast(context)?.single_op(|a| a.tan(), "tan")
+    }
+}
+
+// Handler for pi command — push the constant pi.
+struct PiCommand;
+
+impl CommandHandler for PiCommand {
+    fn execute(&self, context: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
+        let rpn_ctx = downcast(context)?;
+        rpn_ctx.push_x(PI);
+        rpn_ctx.display();
+        Ok(())
+    }
+}
+
+// ================================================================================================
+// Command handlers — memory registers
+// ================================================================================================
+
+// Handler for sto command — store the top of the stack into a register.
+struct StoCommand;
+
+impl CommandHandler for StoCommand {
+    fn execute(&self, context: &mut dyn ExecutionContext, args: &ParsedArgs) -> Result<()> {
+        let index = parse_register_index(args)?;
+        downcast(context)?.store(index)
+    }
+}
+
+// Handler for rcl command — push a register's value onto the stack.
+struct RclCommand;
+
+impl CommandHandler for RclCommand {
+    fn execute(&self, context: &mut dyn ExecutionContext, args: &ParsedArgs) -> Result<()> {
+        let index = parse_register_index(args)?;
+        let rpn_ctx = downcast(context)?;
+        rpn_ctx.recall(index);
+        rpn_ctx.display();
+        Ok(())
+    }
+}
+
+// ================================================================================================
+// Main application
+//
+//  - Load the configuration file (once, shared with ConfigPlugin)
+//  - Register command handlers and the SysInfo/Config plugins
+//  - Build, then dispatch to CLI, REPL, or batch script mode
+// ================================================================================================
+fn main() -> Result<()> {
+    println!("🔢 Advanced RPN Calculator — HP-41CX-flavored — Powered by dynamic-cli");
+    println!("════════════════════════════════════════════════════════════════════\n");
+
+    // Loaded once so the same CommandsConfig can be handed both to the
+    // builder and to ConfigPlugin::with_config() — CliBuilder::build()
+    // does not attach config to plugins on its own (see #44/#47).
+    let config = dynamic_cli::config::load_config("examples/configs/advanced_rpn.yaml")?;
+
+    let app = CliBuilder::new()
+        .config(config.clone())
+        .context(Box::new(AdvancedRpnContext::default()))
+        .register_sync_handler("push_command", Box::new(PushCommand))
+        .register_sync_handler("pop_command", Box::new(PopCommand))
+        .register_sync_handler("lastx_command", Box::new(LastXCommand))
+        .register_sync_handler("swap_command", Box::new(SwapCommand))
+        .register_sync_handler("peek_command", Box::new(PeekCommand))
+        .register_sync_handler("show_command", Box::new(ShowCommand))
+        .register_sync_handler("clear_command", Box::new(ClearCommand))
+        .register_sync_handler("add_function", Box::new(AddCommand))
+        .register_sync_handler("sub_function", Box::new(SubCommand))
+        .register_sync_handler("mul_function", Box::new(MulCommand))
+        .register_sync_handler("div_function", Box::new(DivCommand))
+        .register_sync_handler("pow_function", Box::new(PowCommand))
+        .register_sync_handler("ln_function", Box::new(LnCommand))
+        .register_sync_handler("log10_function", Box::new(Log10Command))
+        .register_sync_handler("exp_function", Box::new(ExpCommand))
+        .register_sync_handler("sqrt_function", Box::new(SqrtCommand))
+        .register_sync_handler("sq_function", Box::new(SqCommand))
+        .register_sync_handler("inv_function", Box::new(InvCommand))
+        .register_sync_handler("chs_function", Box::new(ChsCommand))
+        .register_sync_handler("sin_function", Box::new(SinCommand))
+        .register_sync_handler("cos_function", Box::new(CosCommand))
+        .register_sync_handler("tan_function", Box::new(TanCommand))
+        .register_sync_handler("pi_function", Box::new(PiCommand))
+        .register_sync_handler("sto_command", Box::new(StoCommand))
+        .register_sync_handler("rcl_command", Box::new(RclCommand))
+        .register_plugin(Box::new(SysInfoPlugin::new()))
+        .register_plugin(Box::new(ConfigPlugin::new().with_config(config)))
+        .build()?;
+
+    // `--script <path>` switches to batch mode instead of the usual
+    // CLI/REPL auto-detection (#41). Anything else falls through to
+    // `app.run()` (which re-reads `std::env::args()` itself), where
+    // `:load <path>` remains available from inside an interactive REPL
+    // session.
+    let cli_args: Vec<String> = std::env::args().skip(1).collect();
+    if let Some(script_flag_pos) = cli_args.iter().position(|a| a == "--script") {
+        let path = cli_args.get(script_flag_pos + 1).cloned().ok_or_else(|| {
+            DynamicCliError::Parse(ParseError::InvalidSyntax {
+                details: "--script requires a file path".to_string(),
+                hint: Some("Usage: --script <path/to/script.txt>".to_string()),
+            })
+        })?;
+
+        let outcome = app.run_script(path, ScriptErrorPolicy::Continue)?;
+        println!(
+            "\n{}/{} script line(s) succeeded",
+            outcome.lines_succeeded, outcome.lines_executed
+        );
+        for (line_number, error) in &outcome.failures {
+            eprintln!("  line {}: {}", line_number, error);
+        }
+        return Ok(());
+    }
+
+    app.run()
+}
+
+// ================================================================================================
+// Tests
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_context_push_pop() {
+        let mut ctx = AdvancedRpnContext::default();
+        ctx.push(35.0);
+        ctx.push(10.0);
+        assert_eq!(ctx.pop().unwrap(), 10.0);
+        assert_eq!(ctx.pop().unwrap(), 35.0);
+        assert!(ctx.pop().is_err());
+    }
+
+    #[test]
+    fn test_context_sub_and_div_use_hp_convention() {
+        // HP RPN convention: "10 ENTER 3 -" = 10 - 3 = 7 (Y - X, not X - Y).
+        let mut ctx = AdvancedRpnContext::default();
+        ctx.push_x(10.0);
+        ctx.push_x(3.0);
+        ctx.binary_op(|a, b| b - a, "-").unwrap();
+        assert_eq!(ctx.peek(), Some(7.0));
+
+        // "20 ENTER 4 /" = 20 / 4 = 5 (Y / X, not X / Y).
+        let mut ctx = AdvancedRpnContext::default();
+        ctx.push_x(20.0);
+        ctx.push_x(4.0);
+        ctx.binary_op(|a, b| b / a, "/").unwrap();
+        assert_eq!(ctx.peek(), Some(5.0));
+    }
+
+    #[test]
+    fn test_context_binary_and_unary_ops() {
+        let mut ctx = AdvancedRpnContext::default();
+        ctx.push_x(5.0);
+        ctx.push_x(25.0);
+        ctx.binary_op(|a, b| a * b, "*").unwrap();
+        assert_eq!(ctx.peek(), Some(125.0));
+
+        ctx.clear();
+        ctx.push_x(PI);
+        ctx.single_op(|a| a.cos(), "cos").unwrap();
+        assert!((ctx.peek().unwrap() - (-1.0)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_context_sto_rcl_roundtrip() {
+        let mut ctx = AdvancedRpnContext::default();
+        ctx.push(42.0);
+        ctx.store(3).unwrap();
+        // store() does not pop.
+        assert_eq!(ctx.peek(), Some(42.0));
+
+        ctx.clear();
+        assert_eq!(ctx.peek(), None);
+
+        ctx.recall(3);
+        assert_eq!(ctx.peek(), Some(42.0));
+    }
+
+    #[test]
+    fn test_context_store_on_empty_stack_errors() {
+        let mut ctx = AdvancedRpnContext::default();
+        assert!(ctx.store(0).is_err());
+    }
+
+    #[test]
+    fn test_context_recall_default_register_is_zero() {
+        let mut ctx = AdvancedRpnContext::default();
+        ctx.recall(5);
+        assert_eq!(ctx.peek(), Some(0.0));
+    }
+
+    #[test]
+    fn test_parse_register_index_accepts_bounds() {
+        let mut args = HashMap::new();
+        args.insert("register".to_string(), "0".to_string());
+        assert_eq!(
+            parse_register_index(&ParsedArgs::from_scalars(args)).unwrap(),
+            0
+        );
+
+        let mut args = HashMap::new();
+        args.insert("register".to_string(), "9".to_string());
+        assert_eq!(
+            parse_register_index(&ParsedArgs::from_scalars(args)).unwrap(),
+            9
+        );
+    }
+
+    #[test]
+    fn test_parse_register_index_rejects_out_of_range() {
+        let mut args = HashMap::new();
+        args.insert("register".to_string(), "10".to_string());
+        assert!(parse_register_index(&ParsedArgs::from_scalars(args)).is_err());
+
+        let mut args = HashMap::new();
+        args.insert("register".to_string(), "-1".to_string());
+        assert!(parse_register_index(&ParsedArgs::from_scalars(args)).is_err());
+    }
+
+    #[test]
+    fn test_parse_register_index_rejects_non_integer() {
+        let mut args = HashMap::new();
+        args.insert("register".to_string(), "abc".to_string());
+        assert!(parse_register_index(&ParsedArgs::from_scalars(args)).is_err());
+    }
+
+    #[test]
+    fn test_pow_command_sequence() {
+        let ctx_test = AdvancedRpnContext::default();
+        let mut exec: Box<dyn ExecutionContext> = Box::new(ctx_test);
+
+        let push = PushCommand;
+        let mut args = HashMap::new();
+        args.insert("value".to_string(), "2".to_string());
+        push.execute(exec.as_mut(), &ParsedArgs::from_scalars(args))
+            .unwrap();
+
+        let mut args = HashMap::new();
+        args.insert("value".to_string(), "10".to_string());
+        push.execute(exec.as_mut(), &ParsedArgs::from_scalars(args))
+            .unwrap();
+
+        // Stack (bottom → top): [2, 10]. pow pops (x=10, y=2) and computes
+        // y^x = 2^10 = 1024, matching binary_op's (x, y) pop order.
+        PowCommand
+            .execute(exec.as_mut(), &ParsedArgs::from_scalars(HashMap::new()))
+            .unwrap();
+
+        let ctx = downcast_ref::<AdvancedRpnContext>(exec.as_ref()).unwrap();
+        assert_eq!(ctx.peek(), Some(1024.0));
+    }
+
+    #[test]
+    fn test_sto_rcl_command_roundtrip() {
+        let ctx_test = AdvancedRpnContext::default();
+        let mut exec: Box<dyn ExecutionContext> = Box::new(ctx_test);
+
+        let push = PushCommand;
+        let mut args = HashMap::new();
+        args.insert("value".to_string(), "7".to_string());
+        push.execute(exec.as_mut(), &ParsedArgs::from_scalars(args))
+            .unwrap();
+
+        let mut args = HashMap::new();
+        args.insert("register".to_string(), "4".to_string());
+        StoCommand
+            .execute(exec.as_mut(), &ParsedArgs::from_scalars(args.clone()))
+            .unwrap();
+
+        ClearCommand
+            .execute(exec.as_mut(), &ParsedArgs::from_scalars(HashMap::new()))
+            .unwrap();
+
+        RclCommand
+            .execute(exec.as_mut(), &ParsedArgs::from_scalars(args))
+            .unwrap();
+
+        let ctx = downcast_ref::<AdvancedRpnContext>(exec.as_ref()).unwrap();
+        assert_eq!(ctx.peek(), Some(7.0));
+    }
+
+    #[test]
+    fn test_sqrt_command() {
+        let ctx_test = AdvancedRpnContext::default();
+        let mut exec: Box<dyn ExecutionContext> = Box::new(ctx_test);
+
+        let push = PushCommand;
+        let mut args = HashMap::new();
+        args.insert("value".to_string(), "16".to_string());
+        push.execute(exec.as_mut(), &ParsedArgs::from_scalars(args))
+            .unwrap();
+
+        SqrtCommand
+            .execute(exec.as_mut(), &ParsedArgs::from_scalars(HashMap::new()))
+            .unwrap();
+
+        let ctx = downcast_ref::<AdvancedRpnContext>(exec.as_ref()).unwrap();
+        assert_eq!(ctx.peek(), Some(4.0));
+    }
+}

--- a/examples/configs/advanced_rpn.yaml
+++ b/examples/configs/advanced_rpn.yaml
@@ -1,0 +1,269 @@
+# Advanced RPN Calculator configuration file
+#
+# Extends simple_rpn.yaml with HP-41CX-inspired scientific functions and
+# a 10-register memory bank (sto/rcl), plus the sysinfo/config commands
+# contributed by SysInfoPlugin and ConfigPlugin (feature-gated).
+#
+# In memory of the awesome Hewlett Packard 41 CX.
+
+metadata:
+  version: "0.2.0"
+  prompt: "arpn"
+  prompt_suffix: " > "
+
+commands:
+
+  # ── Stack manipulation ─────────────────────────────────────────────
+
+  - name: push
+    aliases: []
+    description: "Push a number onto the stack, and store it to last x register"
+    required: true
+    arguments:
+      - name: value
+        arg_type: float
+        required: true
+        description: "The number to push"
+        validation: []
+    options: []
+    implementation: "push_command"
+
+  - name: pop
+    aliases: []
+    description: "Pop and display the top value from the stack"
+    required: false
+    arguments: []
+    options: []
+    implementation: "pop_command"
+
+  - name: lastx
+    aliases: []
+    description: "Display the last pushed value onto the stack"
+    required: false
+    arguments: []
+    options: []
+    implementation: "lastx_command"
+
+  - name: swap
+    aliases: ["X<>Y"]
+    description: "Exchange top of the stack and the previous record"
+    required: false
+    arguments: []
+    options: []
+    implementation: "swap_command"
+
+  - name: peek
+    aliases: []
+    description: "Display the top value without remove it"
+    required: false
+    arguments: []
+    options: []
+    implementation: "peek_command"
+
+  - name: show
+    aliases: ["display", "stack"]
+    description: "Display the entire stack as a list"
+    required: false
+    arguments: []
+    options: []
+    implementation: "show_command"
+
+  - name: clear
+    aliases: []
+    description: "Clear the entire stack and last x register"
+    required: false
+    arguments: []
+    options: []
+    implementation: "clear_command"
+
+  # ── Arithmetic operations ──────────────────────────────────────────
+
+  - name: add
+    aliases: ["+"]
+    description: "Pop two values, push their sum"
+    required: true
+    arguments: []
+    options: []
+    implementation: "add_function"
+
+  - name: sub
+    aliases: ["-"]
+    description: "Pop two values, push their difference"
+    required: true
+    arguments: []
+    options: []
+    implementation: "sub_function"
+
+  - name: mul
+    aliases: ["*"]
+    description: "Pop two values, push their product"
+    required: true
+    arguments: []
+    options: []
+    implementation: "mul_function"
+
+  - name: div
+    aliases: ["/"]
+    description: "Pop two values, push their quotient"
+    required: false
+    arguments: []
+    options: []
+    implementation: "div_function"
+
+  # ── Scientific functions (HP-41CX-inspired) ────────────────────────
+
+  - name: ln
+    aliases: []
+    description: "Natural logarithm"
+    required: false
+    arguments: []
+    options: []
+    implementation: "ln_function"
+
+  - name: log10
+    aliases: ["log"]
+    description: "Base-10 logarithm"
+    required: false
+    arguments: []
+    options: []
+    implementation: "log10_function"
+
+  - name: exp
+    aliases: []
+    description: "Natural exponential (e^x)"
+    required: false
+    arguments: []
+    options: []
+    implementation: "exp_function"
+
+  - name: sqrt
+    aliases: []
+    description: "Square root"
+    required: false
+    arguments: []
+    options: []
+    implementation: "sqrt_function"
+
+  - name: sq
+    aliases: ["x2"]
+    description: "Square (x^2)"
+    required: false
+    arguments: []
+    options: []
+    implementation: "sq_function"
+
+  - name: inv
+    aliases: ["1/x"]
+    description: "Reciprocal (1/x)"
+    required: false
+    arguments: []
+    options: []
+    implementation: "inv_function"
+
+  - name: pow
+    aliases: ["y^x"]
+    description: "Pop two values (y, x), push y raised to the power x"
+    required: false
+    arguments: []
+    options: []
+    implementation: "pow_function"
+
+  - name: chs
+    aliases: ["neg"]
+    description: "Change sign of the top of the stack"
+    required: false
+    arguments: []
+    options: []
+    implementation: "chs_function"
+
+  - name: sin
+    aliases: []
+    description: "Sine (radians)"
+    required: false
+    arguments: []
+    options: []
+    implementation: "sin_function"
+
+  - name: cos
+    aliases: []
+    description: "Cosine (radians)"
+    required: false
+    arguments: []
+    options: []
+    implementation: "cos_function"
+
+  - name: tan
+    aliases: []
+    description: "Tangent (radians)"
+    required: false
+    arguments: []
+    options: []
+    implementation: "tan_function"
+
+  - name: pi
+    aliases: []
+    description: "Push the constant pi onto the stack"
+    required: false
+    arguments: []
+    options: []
+    implementation: "pi_function"
+
+  # ── Memory registers (sto/rcl, HP-41-style, simplified to 10 slots) ─
+
+  - name: sto
+    aliases: []
+    description: "Store the top of the stack into register 0-9 (does not pop)"
+    required: true
+    arguments:
+      - name: register
+        arg_type: integer
+        required: true
+        description: "Register index (0-9)"
+        validation:
+          - min: 0
+            max: 9
+    options: []
+    implementation: "sto_command"
+
+  - name: rcl
+    aliases: []
+    description: "Push the value stored in register 0-9 onto the stack"
+    required: true
+    arguments:
+      - name: register
+        arg_type: integer
+        required: true
+        description: "Register index (0-9)"
+        validation:
+          - min: 0
+            max: 9
+    options: []
+    implementation: "rcl_command"
+
+  # ── Contributed by SysInfoPlugin / ConfigPlugin (feature-gated) ────
+
+  - name: sysinfo
+    aliases: []
+    description: "Show runtime/OS information"
+    required: false
+    arguments: []
+    options: []
+    implementation: "sysinfo_show"
+
+  - name: config-show
+    aliases: []
+    description: "Show the loaded configuration as YAML"
+    required: false
+    arguments: []
+    options: []
+    implementation: "config_show"
+
+  - name: config-validate
+    aliases: []
+    description: "Re-validate the loaded configuration"
+    required: false
+    arguments: []
+    options: []
+    implementation: "config_validate"
+
+global_options: []

--- a/examples/configs/advanced_rpn_demo.txt
+++ b/examples/configs/advanced_rpn_demo.txt
@@ -1,0 +1,36 @@
+# Advanced RPN Calculator — demo script
+#
+# Usable both ways:
+#   cargo run --example advanced_rpn_calculator --features sysinfo-plugin,config-plugin -- --script examples/configs/advanced_rpn_demo.txt
+#   (inside the REPL)  :load examples/configs/advanced_rpn_demo.txt
+#
+# Blank lines and lines starting with '#' are ignored by both run_script()
+# and the REPL's :load.
+
+# (3 + 4) * 5  — classic RPN warm-up
+push 3
+push 4
+add
+push 5
+mul
+show
+
+# Quadratic-ish scratchpad using the memory bank: store the result above
+# into register 0, then keep going.
+sto 0
+clear
+rcl 0
+sq
+show
+
+# Scientific functions
+push 2
+sqrt
+show
+
+pi
+show
+
+# Introspection commands, contributed by SysInfoPlugin / ConfigPlugin
+sysinfo
+config-show

--- a/examples/file_manager.rs
+++ b/examples/file_manager.rs
@@ -241,11 +241,7 @@ impl CommandHandler for SearchCommand {
         }
 
         // Simple pattern matching (just extension for now)
-        let extension = if pattern.starts_with("*.") {
-            Some(&pattern[2..])
-        } else {
-            None
-        };
+        let extension = pattern.strip_prefix("*.");
 
         // Search files
         let mut matches = Vec::new();

--- a/examples/rpn_calculator.rs
+++ b/examples/rpn_calculator.rs
@@ -126,7 +126,7 @@ impl SimpleRpnContext {
         let y = self.pop()?;
         let result = operation(x, y);
         self.push(result);
-        println!("  → {} {} {} = {}", x, y, operator_name, result);
+        println!("  → {} {} {} = {}", y, x, operator_name, result);
         Ok(())
     }
 
@@ -355,7 +355,7 @@ impl CommandHandler for SubCommand {
             })
         })?;
 
-        rpn_ctx.binary_op(|a, b| a - b, "-")?;
+        rpn_ctx.binary_op(|a, b| b - a, "-")?;
         Ok(())
     }
 }
@@ -392,7 +392,7 @@ impl CommandHandler for DivCommand {
             })
         })?;
 
-        rpn_ctx.binary_op(|a, b| a / b, "/")?;
+        rpn_ctx.binary_op(|a, b| b / a, "/")?;
         Ok(())
     }
 }
@@ -488,6 +488,23 @@ mod tests {
         ctx_test.push_x(25.0);
         ctx_test.binary_op(|a, b| a * b, "*").unwrap();
         assert_eq!(ctx_test.peek(), Some(125.0));
+    }
+
+    #[test]
+    fn test_rpn_context_sub_and_div_use_hp_convention() {
+        // HP RPN convention: "10 ENTER 3 -" = 10 - 3 = 7 (Y - X, not X - Y).
+        let mut ctx = SimpleRpnContext::default();
+        ctx.push_x(10.0);
+        ctx.push_x(3.0);
+        ctx.binary_op(|a, b| b - a, "-").unwrap();
+        assert_eq!(ctx.peek(), Some(7.0));
+
+        // "20 ENTER 4 /" = 20 / 4 = 5 (Y / X, not X / Y).
+        let mut ctx = SimpleRpnContext::default();
+        ctx.push_x(20.0);
+        ctx.push_x(4.0);
+        ctx.binary_op(|a, b| b / a, "/").unwrap();
+        assert_eq!(ctx.peek(), Some(5.0));
     }
 
     #[test]

--- a/examples/rpn_calculator.rs
+++ b/examples/rpn_calculator.rs
@@ -39,9 +39,9 @@
 use dynamic_cli::prelude::*;
 use std::any::Any;
 
-/// ================================================================================================
-/// Execution context
-/// ================================================================================================
+// ================================================================================================
+// Execution context
+// ================================================================================================
 
 /// Execution context for the simple rpn calculator
 ///
@@ -63,7 +63,7 @@ impl SimpleRpnContext {
 
     /// Push a value onto the stack and lastx register
     fn push_x(&mut self, value: f64) {
-        self.last_x = value.clone();
+        self.last_x = value;
         self.push(value);
     }
 
@@ -78,7 +78,7 @@ impl SimpleRpnContext {
 
     /// Show the last x register
     fn last_x(&self) -> f64 {
-        self.last_x.clone()
+        self.last_x
     }
 
     /// Swap registers
@@ -152,13 +152,13 @@ impl ExecutionContext for SimpleRpnContext {
     }
 }
 
-/// ================================================================================================
-/// Command handlers
-///
-///  - Stack commands
-///  - Arithmetic functions
-///
-/// ================================================================================================
+// ================================================================================================
+// Command handlers
+//
+//  - Stack commands
+//  - Arithmetic functions
+//
+// ================================================================================================
 
 /// handler for push command
 ///
@@ -202,7 +202,6 @@ impl CommandHandler for PushCommand {
 /// Handler for pop command
 ///
 /// Removes and display the top value
-
 struct PopCommand;
 
 impl CommandHandler for PopCommand {
@@ -224,7 +223,6 @@ impl CommandHandler for PopCommand {
 /// Handler for lastx command
 ///
 /// Displays the last x register which stores the last value pushed
-
 struct LastXCommand;
 
 impl CommandHandler for LastXCommand {
@@ -246,7 +244,6 @@ impl CommandHandler for LastXCommand {
 /// Handler for swap command
 ///
 /// Exchange x register and y register in the stack
-
 struct SwapCommand;
 
 impl CommandHandler for SwapCommand {
@@ -268,7 +265,6 @@ impl CommandHandler for SwapCommand {
 /// Handler for peek command
 ///
 /// Displays the top value without removes it
-
 struct PeekCommand;
 
 impl CommandHandler for PeekCommand {
@@ -292,7 +288,6 @@ impl CommandHandler for PeekCommand {
 /// Handler for show command
 ///
 /// shows the entire stack as a list
-
 struct ShowCommand;
 
 impl CommandHandler for ShowCommand {
@@ -312,7 +307,6 @@ impl CommandHandler for ShowCommand {
 /// Handler for clear command
 ///
 /// sets the rpn context to default values
-
 struct ClearCommand;
 
 impl CommandHandler for ClearCommand {
@@ -332,7 +326,6 @@ impl CommandHandler for ClearCommand {
 /// Handler for add function
 ///
 /// Pops two values and pushes their sum
-
 struct AddCommand;
 
 impl CommandHandler for AddCommand {
@@ -351,7 +344,6 @@ impl CommandHandler for AddCommand {
 /// Handler for sub function
 ///
 /// Pops two value and pushes their difference
-
 struct SubCommand;
 
 impl CommandHandler for SubCommand {
@@ -371,7 +363,6 @@ impl CommandHandler for SubCommand {
 /// Handler for mul function
 ///
 /// Pops two values and pushed their product
-
 struct MulCommand;
 
 impl CommandHandler for MulCommand {
@@ -390,7 +381,6 @@ impl CommandHandler for MulCommand {
 /// Handler for div function
 ///
 /// Pops two values and pushes their quotient
-
 struct DivCommand;
 
 impl CommandHandler for DivCommand {
@@ -410,7 +400,6 @@ impl CommandHandler for DivCommand {
 /// Hander fon natural logarithm
 ///
 /// Pops the value and pushes the natural logarithm
-
 struct LnFunction;
 
 impl CommandHandler for LnFunction {
@@ -427,13 +416,13 @@ impl CommandHandler for LnFunction {
     }
 }
 
-/// ================================================================================================
-/// Main application
-///
-///  - Load the configuration file
-///  - Register command and function
-///  - Build and run the app
-/// ================================================================================================
+// ================================================================================================
+// Main application
+//
+//  - Load the configuration file
+//  - Register command and function
+//  - Build and run the app
+// ================================================================================================
 fn main() -> Result<()> {
     println!("🔢 Simple RPN Calculator - Powered by dynamic-cli");
     println!("═════════════════════════════════════════════════\n");
@@ -458,9 +447,9 @@ fn main() -> Result<()> {
     app.run()
 }
 
-/// ================================================================================================
-/// Tests
-/// ================================================================================================
+// ================================================================================================
+// Tests
+// ================================================================================================
 
 #[cfg(test)]
 mod tests {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -763,6 +763,47 @@ impl CliApp {
         cli.run(args)
     }
 
+    /// Run a batch of command lines read from a file (#41).
+    ///
+    /// Convenience wrapper around
+    /// [`CliInterface::run_script`][crate::interface::CliInterface::run_script]
+    /// — see there for the line format, tokenization, and error-policy
+    /// details.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use dynamic_cli::prelude::*;
+    /// # #[derive(Default)]
+    /// # struct MyContext;
+    /// # impl ExecutionContext for MyContext {
+    /// #     fn as_any(&self) -> &dyn std::any::Any { self }
+    /// #     fn as_any_mut(&mut self) -> &mut dyn std::any::Any { self }
+    /// # }
+    /// # struct MyHandler;
+    /// # impl CommandHandler for MyHandler {
+    /// #     fn execute(&self, _: &mut dyn ExecutionContext, _: &dynamic_cli::parser::ParsedArgs) -> dynamic_cli::Result<()> { Ok(()) }
+    /// # }
+    /// # fn main() -> dynamic_cli::Result<()> {
+    /// # let app = CliBuilder::new()
+    /// #     .config_file("commands.yaml")
+    /// #     .context(Box::new(MyContext::default()))
+    /// #     .register_sync_handler("handler", Box::new(MyHandler))
+    /// #     .build()?;
+    /// let outcome = app.run_script("commands.txt", ScriptErrorPolicy::Continue)?;
+    /// println!("{}/{} lines succeeded", outcome.lines_succeeded, outcome.lines_executed);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn run_script(
+        self,
+        path: impl AsRef<std::path::Path>,
+        policy: crate::interface::ScriptErrorPolicy,
+    ) -> Result<crate::interface::ScriptOutcome> {
+        let cli = CliInterface::new(self.registry, self.context);
+        cli.run_script(path, policy)
+    }
+
     /// Run in REPL mode
     ///
     /// Enters an interactive loop that continues until the user exits.

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -202,11 +202,11 @@ mod tests {
         }
     }
 
-    /// Another context type for testing type safety
-    #[derive(Default)]
-    struct AnotherContext {
-        value: i32,
-    }
+    /// Another context type for testing type safety.
+    ///
+    /// Unit struct: only its distinct *type* matters for this
+    /// wrong-context-type test, no payload is ever read.
+    struct AnotherContext;
 
     impl ExecutionContext for AnotherContext {
         fn as_any(&self) -> &dyn Any {
@@ -293,7 +293,7 @@ mod tests {
             Ok(())
         }
 
-        let mut wrong_ctx = AnotherContext::default();
+        let mut wrong_ctx = AnotherContext;
 
         // Should fail because we're passing the wrong context type
         let result = command_expecting_test_context(&mut wrong_ctx);
@@ -308,8 +308,10 @@ mod tests {
             Ok(app_ctx.command_count)
         }
 
-        let mut ctx = TestAppContext::default();
-        ctx.command_count = 42;
+        let ctx = TestAppContext {
+            command_count: 42,
+            ..Default::default()
+        };
 
         let count = read_command_count(&ctx).unwrap();
         assert_eq!(count, 42);

--- a/src/context/traits.rs
+++ b/src/context/traits.rs
@@ -299,11 +299,11 @@ mod tests {
         }
     }
 
-    /// Alternative context type for testing type mismatch
-    #[derive(Default)]
-    struct OtherContext {
-        data: Vec<u8>,
-    }
+    /// Alternative context type for testing type mismatch.
+    ///
+    /// Unit struct: only its distinct *type* matters for these
+    /// downcast-mismatch tests, no payload is ever read.
+    struct OtherContext;
 
     impl ExecutionContext for OtherContext {
         fn as_any(&self) -> &dyn Any {
@@ -487,7 +487,7 @@ mod tests {
             Ok(())
         }
 
-        let mut ctx = OtherContext::default();
+        let mut ctx = OtherContext;
 
         // Should fail because we're passing OtherContext
         let result = handler(&mut ctx);
@@ -534,7 +534,7 @@ mod tests {
 
         // Verify changes
         assert_eq!(*ctx.counters.get("visits").unwrap(), 1);
-        assert_eq!(ctx.flags[0], false);
+        assert!(!ctx.flags[0]);
         assert!(ctx.optional_data.is_none());
     }
 

--- a/src/executor/traits.rs
+++ b/src/executor/traits.rs
@@ -573,7 +573,6 @@ mod tests {
     #[test]
     fn test_context_downcast_failure() {
         // Use a different context type to trigger downcast failure
-        #[derive(Default)]
         struct WrongContext;
 
         impl ExecutionContext for WrongContext {
@@ -587,7 +586,7 @@ mod tests {
         }
 
         let handler = HelloCommand;
-        let mut wrong_context = WrongContext::default();
+        let mut wrong_context = WrongContext;
         let args = ParsedArgs::from_scalars(HashMap::new());
 
         let result = handler.execute(&mut wrong_context, &args);
@@ -604,8 +603,9 @@ mod tests {
     #[test]
     fn test_context_state_modification() {
         let handler = StatefulCommand;
-        let mut context = TestContext::default();
-        context.state = "initial".to_string();
+        let mut context = TestContext {
+            state: "initial".to_string(),
+        };
         let args = scalar_args([("value", "_modified")]);
 
         let result = handler.execute(&mut context, &args);

--- a/src/help/mod.rs
+++ b/src/help/mod.rs
@@ -472,6 +472,11 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
+    // Intentional: this test locks in the public API guarantee that
+    // `::new()` and `::default()` are equivalent construction paths
+    // (documented at the struct's rustdoc, line ~111) — not leftover
+    // test scaffolding, so the `::default()` call must stay.
+    #[allow(clippy::default_constructed_unit_structs)]
     fn test_new_and_default_are_equivalent() {
         // Both construction paths compile and produce the same type.
         let _a = DefaultHelpFormatter::new();

--- a/src/interface/cli.rs
+++ b/src/interface/cli.rs
@@ -26,9 +26,10 @@
 //! ```
 
 use crate::context::ExecutionContext;
-use crate::error::{display_error, DynamicCliError, Result};
-use crate::parser::{CliParser, ParsedArgs};
+use crate::error::{display_error, DynamicCliError, ExecutionError, Result};
+use crate::parser::{CliParser, ParsedArgs, ReplParser};
 use crate::registry::CommandRegistry;
+use std::path::Path;
 use std::process;
 
 /// CLI (Command-Line Interface) handler
@@ -145,6 +146,17 @@ impl CliInterface {
             ));
         }
 
+        self.dispatch(&args)
+    }
+
+    /// Resolve, parse, and execute a single already-tokenized command line.
+    ///
+    /// Shared by [`run`][Self::run] (one dispatch from CLI args) and
+    /// [`run_script`][Self::run_script] (one dispatch per script line) —
+    /// the actual resolution/parsing/execution logic lives here exactly
+    /// once, per DD-024's "reuse the existing `ParsedArgs` path, no
+    /// duplicate parsing logic" requirement (see #41).
+    fn dispatch(&mut self, args: &[String]) -> Result<()> {
         // First argument is the command name
         let command_name = &args[0];
 
@@ -175,8 +187,9 @@ impl CliInterface {
         // Get handler and execute command. Sync is tried first (unchanged
         // behaviour); if no sync handler matches, fall through to the async
         // path (DD-022) and drive it via `block_on`. Safe here because
-        // `run()` is a strictly sequential, one-shot dispatch — there is no
-        // other async task waiting behind it that `block_on` could starve.
+        // `run()`/`run_script()` are strictly sequential, one-shot dispatch —
+        // there is no other async task waiting behind it that `block_on`
+        // could starve.
         if let Some(handler) = self.registry.get_handler_sync(resolved_name) {
             handler.execute(&mut *self.context, &parsed_args)?;
         } else if let Some(handler) = self.registry.get_handler_async(resolved_name) {
@@ -245,6 +258,163 @@ impl CliInterface {
             }
         }
     }
+
+    /// Run a batch of command lines read from a file (#41).
+    ///
+    /// Each non-blank, non-comment (`#`-prefixed) line is tokenized the
+    /// same quote-aware way as a typed REPL line (via
+    /// [`ReplParser::tokenize`]), then dispatched through the exact same
+    /// resolve → parse → execute path as [`run`][Self::run] — no
+    /// duplicate parsing logic, and repeatable options (DD-024) are fully
+    /// preserved since dispatch goes through `parse_typed()` either way.
+    ///
+    /// # Error policy
+    ///
+    /// `policy` decides what happens when a line fails:
+    /// - [`ScriptErrorPolicy::Abort`]: stop immediately, returning `Err`
+    ///   for the failing line. Lines before it have already run.
+    /// - [`ScriptErrorPolicy::Continue`]: record the failure and proceed
+    ///   to the next line. The method still returns `Ok`, with every
+    ///   failure listed in the returned [`ScriptOutcome`].
+    ///
+    /// Every failure — whether it aborts the run or not — is reported
+    /// with its 1-based line number, wrapped in
+    /// [`ExecutionError::CommandFailed`][crate::error::ExecutionError::CommandFailed]
+    /// (reusing the existing error hierarchy; no new enum variant, so no
+    /// breaking change to `ExecutionError`'s non-`#[non_exhaustive]`
+    /// shape).
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use dynamic_cli::interface::{CliInterface, ScriptErrorPolicy};
+    /// use dynamic_cli::prelude::*;
+    ///
+    /// # #[derive(Default)]
+    /// # struct MyContext;
+    /// # impl ExecutionContext for MyContext {
+    /// #     fn as_any(&self) -> &dyn std::any::Any { self }
+    /// #     fn as_any_mut(&mut self) -> &mut dyn std::any::Any { self }
+    /// # }
+    /// # fn main() -> dynamic_cli::Result<()> {
+    /// let registry = CommandRegistry::new();
+    /// let context = Box::new(MyContext::default());
+    /// let cli = CliInterface::new(registry, context);
+    ///
+    /// let outcome = cli.run_script("commands.txt", ScriptErrorPolicy::Continue)?;
+    /// println!("{}/{} lines succeeded", outcome.lines_succeeded, outcome.lines_executed);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn run_script(
+        mut self,
+        path: impl AsRef<Path>,
+        policy: ScriptErrorPolicy,
+    ) -> Result<ScriptOutcome> {
+        let path = path.as_ref();
+        let content = std::fs::read_to_string(path).map_err(|e| {
+            DynamicCliError::Execution(ExecutionError::CommandFailed(anyhow::anyhow!(
+                "failed to read script file {}: {}",
+                path.display(),
+                e
+            )))
+        })?;
+
+        let mut outcome = ScriptOutcome {
+            lines_executed: 0,
+            lines_succeeded: 0,
+            failures: Vec::new(),
+        };
+
+        for (idx, raw_line) in content.lines().enumerate() {
+            let line_number = idx + 1;
+            let line = raw_line.trim();
+
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+
+            outcome.lines_executed += 1;
+
+            // Scoped so the borrow of `self.registry` ends before
+            // `self.dispatch(&mut self, ...)` needs exclusive access below.
+            // `tokenize` is a pure function of the line text — it doesn't
+            // read `self.registry` — but it lives on `ReplParser`, so a
+            // throwaway instance is the reuse path rather than duplicating
+            // the quote-handling logic here.
+            let tokens_result = {
+                let tokenizer = ReplParser::new(&self.registry);
+                tokenizer.tokenize(line)
+            };
+
+            let tokens = match tokens_result {
+                Ok(t) => t,
+                Err(e) => {
+                    let wrapped = wrap_line_error(line_number, e);
+                    if policy == ScriptErrorPolicy::Abort {
+                        return Err(wrapped);
+                    }
+                    outcome.failures.push((line_number, wrapped));
+                    continue;
+                }
+            };
+
+            if tokens.is_empty() {
+                continue;
+            }
+
+            match self.dispatch(&tokens) {
+                Ok(()) => outcome.lines_succeeded += 1,
+                Err(e) => {
+                    let wrapped = wrap_line_error(line_number, e);
+                    if policy == ScriptErrorPolicy::Abort {
+                        return Err(wrapped);
+                    }
+                    outcome.failures.push((line_number, wrapped));
+                }
+            }
+        }
+
+        Ok(outcome)
+    }
+}
+
+/// Wrap an error with its 1-based script line number, reusing the
+/// existing [`ExecutionError::CommandFailed`] variant so adding
+/// line-number context never requires a breaking change to the error
+/// hierarchy.
+fn wrap_line_error(line_number: usize, source: DynamicCliError) -> DynamicCliError {
+    DynamicCliError::Execution(ExecutionError::CommandFailed(anyhow::anyhow!(
+        "line {}: {}",
+        line_number,
+        source
+    )))
+}
+
+/// What [`CliInterface::run_script`] does when a line fails.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScriptErrorPolicy {
+    /// Stop at the first failing line — [`run_script`][CliInterface::run_script]
+    /// returns `Err` immediately, with the lines before it already run.
+    Abort,
+    /// Record the failure and keep going —
+    /// [`run_script`][CliInterface::run_script] returns `Ok` with every
+    /// failure listed in [`ScriptOutcome::failures`].
+    Continue,
+}
+
+/// Result of a full [`CliInterface::run_script`] run.
+#[derive(Debug)]
+pub struct ScriptOutcome {
+    /// Number of non-blank, non-comment lines dispatched (attempted).
+    pub lines_executed: usize,
+    /// Number of those lines that succeeded.
+    pub lines_succeeded: usize,
+    /// `(1-based line number, wrapped error)` for every line that failed.
+    /// Always empty when `policy` was
+    /// [`ScriptErrorPolicy::Abort`][ScriptErrorPolicy::Abort] and the run
+    /// completed (an abort returns `Err` instead of populating this).
+    pub failures: Vec<(usize, DynamicCliError)>,
 }
 
 #[cfg(test)]
@@ -409,5 +579,142 @@ mod tests {
 
         let result = cli.run(vec!["greet".to_string(), "Alice".to_string()]);
         assert!(result.is_ok());
+    }
+
+    // ========================================================================
+    // run_script tests (#41)
+    // ========================================================================
+
+    fn write_script(content: &str) -> tempfile::NamedTempFile {
+        use std::io::Write;
+        let mut file = tempfile::NamedTempFile::new().expect("failed to create temp script file");
+        file.write_all(content.as_bytes())
+            .expect("failed to write temp script file");
+        file
+    }
+
+    #[test]
+    fn test_run_script_all_lines_succeed() {
+        let registry = create_test_registry();
+        let context = Box::new(TestContext::default());
+        let cli = CliInterface::new(registry, context);
+
+        let script = write_script("test\nt\ntest\n");
+        let outcome = cli
+            .run_script(script.path(), ScriptErrorPolicy::Abort)
+            .expect("run_script should succeed when every line succeeds");
+
+        assert_eq!(outcome.lines_executed, 3);
+        assert_eq!(outcome.lines_succeeded, 3);
+        assert!(outcome.failures.is_empty());
+    }
+
+    #[test]
+    fn test_run_script_skips_blank_lines_and_comments() {
+        let registry = create_test_registry();
+        let context = Box::new(TestContext::default());
+        let cli = CliInterface::new(registry, context);
+
+        let script = write_script("# a comment\n\ntest\n   \n# another\nt\n");
+        let outcome = cli
+            .run_script(script.path(), ScriptErrorPolicy::Abort)
+            .expect("run_script should succeed");
+
+        // Only the two real command lines count.
+        assert_eq!(outcome.lines_executed, 2);
+        assert_eq!(outcome.lines_succeeded, 2);
+    }
+
+    #[test]
+    fn test_run_script_continue_policy_records_failures_and_keeps_going() {
+        let registry = create_test_registry();
+        let context = Box::new(TestContext::default());
+        let cli = CliInterface::new(registry, context);
+
+        let script = write_script("test\nunknown_command\ntest\n");
+        let outcome = cli
+            .run_script(script.path(), ScriptErrorPolicy::Continue)
+            .expect("Continue policy should return Ok even with a failing line");
+
+        assert_eq!(outcome.lines_executed, 3);
+        assert_eq!(outcome.lines_succeeded, 2);
+        assert_eq!(outcome.failures.len(), 1);
+        assert_eq!(outcome.failures[0].0, 2); // 1-based line number
+    }
+
+    #[test]
+    fn test_run_script_abort_policy_stops_at_first_failure() {
+        let registry = create_test_registry();
+        let context = Box::new(TestContext::default());
+        let cli = CliInterface::new(registry, context);
+
+        // A third "test" line would succeed if reached — it must not be.
+        let script = write_script("test\nunknown_command\ntest\n");
+        let result = cli.run_script(script.path(), ScriptErrorPolicy::Abort);
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            DynamicCliError::Execution(ExecutionError::CommandFailed(e)) => {
+                assert!(e.to_string().contains("line 2"));
+            }
+            other => panic!("Expected wrapped CommandFailed error, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_run_script_respects_quoted_tokens() {
+        let mut registry = CommandRegistry::new();
+        let cmd_def = CommandDefinition {
+            name: "greet".to_string(),
+            aliases: vec![],
+            description: "Greet someone".to_string(),
+            required: false,
+            arguments: vec![ArgumentDefinition {
+                name: "name".to_string(),
+                arg_type: ArgumentType::String,
+                required: true,
+                description: "Name to greet".to_string(),
+                validation: vec![],
+                secure: false,
+            }],
+            options: vec![],
+            implementation: "greet_handler".to_string(),
+        };
+
+        struct GreetHandler;
+        impl crate::executor::CommandHandler for GreetHandler {
+            fn execute(
+                &self,
+                _context: &mut dyn ExecutionContext,
+                args: &ParsedArgs,
+            ) -> Result<()> {
+                assert_eq!(args.get_scalar("name"), Some("Alice Wonderland"));
+                Ok(())
+            }
+        }
+
+        registry
+            .register_sync(cmd_def, Box::new(GreetHandler))
+            .unwrap();
+
+        let context = Box::new(TestContext::default());
+        let cli = CliInterface::new(registry, context);
+
+        let script = write_script(r#"greet "Alice Wonderland""#);
+        let outcome = cli
+            .run_script(script.path(), ScriptErrorPolicy::Abort)
+            .expect("quoted argument should tokenize as a single value");
+
+        assert_eq!(outcome.lines_succeeded, 1);
+    }
+
+    #[test]
+    fn test_run_script_missing_file() {
+        let registry = create_test_registry();
+        let context = Box::new(TestContext::default());
+        let cli = CliInterface::new(registry, context);
+
+        let result = cli.run_script("/nonexistent/path/to/script.txt", ScriptErrorPolicy::Abort);
+        assert!(result.is_err());
     }
 }

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -219,7 +219,7 @@ pub mod cli;
 pub mod repl;
 
 // Re-export main types for convenience
-pub use cli::CliInterface;
+pub use cli::{CliInterface, ScriptErrorPolicy, ScriptOutcome};
 pub use repl::ReplInterface;
 
 #[cfg(test)]

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -229,7 +229,6 @@ mod tests {
     use crate::prelude::*;
 
     // Test context
-    #[derive(Default)]
     struct TestContext;
 
     impl ExecutionContext for TestContext {
@@ -280,7 +279,7 @@ mod tests {
             .register_sync(cmd_def, Box::new(TestHandler))
             .unwrap();
 
-        let context = Box::new(TestContext::default());
+        let context = Box::new(TestContext);
         let _cli = CliInterface::new(registry, context);
     }
 
@@ -302,7 +301,7 @@ mod tests {
             .register_sync(cmd_def, Box::new(TestHandler))
             .unwrap();
 
-        let context = Box::new(TestContext::default());
+        let context = Box::new(TestContext);
         let _repl = ReplInterface::new(registry, context, "test".to_string(), None, None);
     }
 }

--- a/src/interface/repl.rs
+++ b/src/interface/repl.rs
@@ -40,7 +40,7 @@ use rustyline::{CompletionType, Config, Context, Editor, Helper};
 
 use crate::config::schema::CommandsConfig;
 use crate::context::ExecutionContext;
-use crate::error::{display_error, DynamicCliError, ExecutionError, Result};
+use crate::error::{display_error, DynamicCliError, ExecutionError, ParseError, Result};
 use crate::help::HelpFormatter;
 use crate::parser::{ParsedArgs, ReplParser};
 use crate::registry::CommandRegistry;
@@ -426,6 +426,82 @@ impl ReplInterface {
         None
     }
 
+    /// Intercept a `:load <path>` line before normal command parsing (#41
+    /// scope extension).
+    ///
+    /// Returns `None` when `line` doesn't start with `:load ` — normal
+    /// dispatch proceeds. Returns `Some(result)` when it does, whether
+    /// the load itself succeeds or fails.
+    ///
+    /// Unlike [`CliInterface::run_script`][crate::interface::CliInterface::run_script],
+    /// there is no error-policy parameter here: a failing line is
+    /// reported inline (via [`display_error`]) and the load always
+    /// continues to the next line, printing a final `succeeded/attempted`
+    /// summary. This matches how the REPL already surfaces errors for
+    /// interactively-typed lines — one at a time, without halting the
+    /// session — rather than the batch abort/continue choice that makes
+    /// sense for a one-shot script run.
+    ///
+    /// Each loaded line is dispatched via [`execute_line`][Self::execute_line]
+    /// itself — the same scalar-only path (DD-024 addendum) as any other
+    /// REPL-typed line, **not**
+    /// [`crate::interface::CliInterface::run_script`]'s typed/repeatable-options
+    /// path. A loaded script is not added to `rustyline` history, and a
+    /// script that `:load`s itself (directly or via another file) will
+    /// recurse until the file handle limit or stack is exhausted — no
+    /// cycle detection is implemented.
+    fn try_handle_load(&mut self, line: &str) -> Option<Result<()>> {
+        let path = line.trim().strip_prefix(":load ").map(str::trim)?;
+
+        if path.is_empty() {
+            return Some(Err(DynamicCliError::Parse(ParseError::InvalidSyntax {
+                details: "`:load` requires a file path".to_string(),
+                hint: Some("Usage: :load <path/to/script.txt>".to_string()),
+            })));
+        }
+
+        Some(self.load_script(path))
+    }
+
+    /// Read `path` and dispatch each non-blank, non-comment (`#`-prefixed)
+    /// line through [`execute_line`][Self::execute_line], continuing past
+    /// any failure. See [`try_handle_load`][Self::try_handle_load] for the
+    /// full behaviour.
+    fn load_script(&mut self, path: &str) -> Result<()> {
+        let content = std::fs::read_to_string(path).map_err(|e| {
+            DynamicCliError::Execution(ExecutionError::CommandFailed(anyhow::anyhow!(
+                "failed to read script file {}: {}",
+                path,
+                e
+            )))
+        })?;
+
+        let mut attempted = 0usize;
+        let mut succeeded = 0usize;
+
+        for (idx, raw_line) in content.lines().enumerate() {
+            let line_number = idx + 1;
+            let script_line = raw_line.trim();
+
+            if script_line.is_empty() || script_line.starts_with('#') {
+                continue;
+            }
+
+            attempted += 1;
+
+            match self.execute_line(script_line) {
+                Ok(()) => succeeded += 1,
+                Err(e) => {
+                    eprintln!("  :load {} — line {}:", path, line_number);
+                    display_error(&e);
+                }
+            }
+        }
+
+        println!(":load {path}: {succeeded}/{attempted} line(s) succeeded");
+        Ok(())
+    }
+
     /// Check whether a parsed command involves at least one secure argument.
     ///
     /// Looks up the command definition in `self.config` (if available) and
@@ -577,6 +653,10 @@ impl ReplInterface {
         if let Some(output) = self.try_handle_help(line) {
             print!("{}", output);
             return Ok(());
+        }
+
+        if let Some(result) = self.try_handle_load(line) {
+            return result;
         }
 
         let parser = ReplParser::new(&self.registry);
@@ -1258,6 +1338,116 @@ mod tests {
         assert!(
             in_history,
             "non-secure command line must be written to history"
+        );
+    }
+
+    // ── :load (#41 scope extension) ─────────────────────────────────────────
+
+    fn write_script(content: &str) -> tempfile::NamedTempFile {
+        use std::io::Write;
+        let mut file = tempfile::NamedTempFile::new().expect("failed to create temp script file");
+        file.write_all(content.as_bytes())
+            .expect("failed to write temp script file");
+        file
+    }
+
+    #[test]
+    fn test_load_executes_each_line_via_execute_line() {
+        let registry = create_test_registry();
+        let context = Box::new(TestContext::default());
+        let mut repl =
+            ReplInterface::new(registry, context, "test".to_string(), None, None).unwrap();
+
+        let script = write_script("test\nt\n");
+        let line = format!(":load {}", script.path().display());
+
+        assert!(repl.execute_line(&line).is_ok());
+
+        let ctx = crate::context::downcast_ref::<TestContext>(&*repl.context).unwrap();
+        assert_eq!(ctx.executed_commands, vec!["test", "test"]);
+    }
+
+    #[test]
+    fn test_load_skips_blank_lines_and_comments() {
+        let registry = create_test_registry();
+        let context = Box::new(TestContext::default());
+        let mut repl =
+            ReplInterface::new(registry, context, "test".to_string(), None, None).unwrap();
+
+        let script = write_script("# a comment\n\ntest\n   \n# another\n");
+        let line = format!(":load {}", script.path().display());
+
+        assert!(repl.execute_line(&line).is_ok());
+
+        let ctx = crate::context::downcast_ref::<TestContext>(&*repl.context).unwrap();
+        assert_eq!(ctx.executed_commands, vec!["test"]);
+    }
+
+    #[test]
+    fn test_load_continues_past_a_failing_line() {
+        let registry = create_test_registry();
+        let context = Box::new(TestContext::default());
+        let mut repl =
+            ReplInterface::new(registry, context, "test".to_string(), None, None).unwrap();
+
+        let script = write_script("test\nunknown_command\ntest\n");
+        let line = format!(":load {}", script.path().display());
+
+        // Unlike CliInterface::run_script(Abort), :load never returns Err
+        // just because a line inside it failed — the failure is displayed
+        // inline and the load proceeds to the next line.
+        let result = repl.execute_line(&line);
+        assert!(result.is_ok());
+
+        let ctx = crate::context::downcast_ref::<TestContext>(&*repl.context).unwrap();
+        assert_eq!(ctx.executed_commands, vec!["test", "test"]);
+    }
+
+    #[test]
+    fn test_load_missing_path_argument_is_an_error() {
+        let registry = create_test_registry();
+        let context = Box::new(TestContext::default());
+        let mut repl =
+            ReplInterface::new(registry, context, "test".to_string(), None, None).unwrap();
+
+        let result = repl.execute_line(":load");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_load_missing_file_is_an_error() {
+        let registry = create_test_registry();
+        let context = Box::new(TestContext::default());
+        let mut repl =
+            ReplInterface::new(registry, context, "test".to_string(), None, None).unwrap();
+
+        let result = repl.execute_line(":load /nonexistent/path/to/script.txt");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_load_line_itself_is_not_added_to_history() {
+        let registry = create_test_registry();
+        let context = Box::new(TestContext::default());
+        let mut repl =
+            ReplInterface::new(registry, context, "test".to_string(), None, None).unwrap();
+
+        let script = write_script("test\n");
+        let line = format!(":load {}", script.path().display());
+        assert!(repl.execute_line(&line).is_ok());
+
+        let history = repl.editor.history();
+        let load_in_history = (0..history.len()).any(|i| {
+            history
+                .get(i, rustyline::history::SearchDirection::Forward)
+                .ok()
+                .flatten()
+                .map(|e| e.entry.starts_with(":load"))
+                .unwrap_or(false)
+        });
+        assert!(
+            !load_in_history,
+            ":load line itself must not be written to history"
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@ pub use help::{DefaultHelpFormatter, HelpFormatter};
 // Plugin system
 #[cfg(feature = "wasm-plugins")]
 pub use plugin::wasm::{WasmPlugin, WasmSerializationFormat};
-pub use plugin::{Plugin, SystemPlugin};
+pub use plugin::{ExitPlugin, HelpPlugin, Plugin, SystemPlugin, VersionPlugin};
 
 // Utility functions
 pub use utils::{
@@ -204,7 +204,7 @@ pub mod prelude {
     // Plugin system
     #[cfg(feature = "wasm-plugins")]
     pub use crate::plugin::wasm::{WasmPlugin, WasmSerializationFormat};
-    pub use crate::plugin::{Plugin, SystemPlugin};
+    pub use crate::plugin::{ExitPlugin, HelpPlugin, Plugin, SystemPlugin, VersionPlugin};
 
     // Utilities (most commonly used)
     pub use crate::utils::{detect_type, is_blank, normalize, parse_bool, parse_float, parse_int};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@ pub use parser::{CliParser, ParsedArgs, ParsedCommand, ReplParser};
 pub use validator::{validate_file_exists, validate_file_extension, validate_range};
 
 // Interface types
-pub use interface::{CliInterface, ReplInterface};
+pub use interface::{CliInterface, ReplInterface, ScriptErrorPolicy, ScriptOutcome};
 
 // Builder types
 pub use builder::{CliApp, CliBuilder};
@@ -137,6 +137,12 @@ pub use help::{DefaultHelpFormatter, HelpFormatter};
 // Plugin system
 #[cfg(feature = "wasm-plugins")]
 pub use plugin::wasm::{WasmPlugin, WasmSerializationFormat};
+#[cfg(feature = "config-plugin")]
+pub use plugin::ConfigPlugin;
+#[cfg(feature = "env-plugin")]
+pub use plugin::EnvPlugin;
+#[cfg(feature = "sysinfo-plugin")]
+pub use plugin::SysInfoPlugin;
 pub use plugin::{ExitPlugin, HelpPlugin, Plugin, SystemPlugin, VersionPlugin};
 
 // Utility functions
@@ -193,7 +199,7 @@ pub mod prelude {
     pub use crate::validator::{validate_file_exists, validate_file_extension, validate_range};
 
     // Interface
-    pub use crate::interface::{CliInterface, ReplInterface};
+    pub use crate::interface::{CliInterface, ReplInterface, ScriptErrorPolicy, ScriptOutcome};
 
     // Builder
     pub use crate::builder::{CliApp, CliBuilder};
@@ -204,6 +210,12 @@ pub mod prelude {
     // Plugin system
     #[cfg(feature = "wasm-plugins")]
     pub use crate::plugin::wasm::{WasmPlugin, WasmSerializationFormat};
+    #[cfg(feature = "config-plugin")]
+    pub use crate::plugin::ConfigPlugin;
+    #[cfg(feature = "env-plugin")]
+    pub use crate::plugin::EnvPlugin;
+    #[cfg(feature = "sysinfo-plugin")]
+    pub use crate::plugin::SysInfoPlugin;
     pub use crate::plugin::{ExitPlugin, HelpPlugin, Plugin, SystemPlugin, VersionPlugin};
 
     // Utilities (most commonly used)

--- a/src/parser/type_parser.rs
+++ b/src/parser/type_parser.rs
@@ -414,6 +414,10 @@ mod tests {
     }
 
     #[test]
+    // `3.14` is an intentional, intuitive decimal literal for testing string
+    // parsing — not a mistyped π. clippy::approx_constant would otherwise
+    // suggest std::f64::consts::PI, which is not what this test is about.
+    #[allow(clippy::approx_constant)]
     fn test_parse_float_decimal() {
         assert_eq!(parse_float("3.14").unwrap(), 3.14);
         assert_eq!(parse_float("-1.5").unwrap(), -1.5);
@@ -448,37 +452,37 @@ mod tests {
     #[test]
     fn test_parse_bool_true_variants() {
         // All true variants
-        assert_eq!(parse_bool("true").unwrap(), true);
-        assert_eq!(parse_bool("True").unwrap(), true);
-        assert_eq!(parse_bool("TRUE").unwrap(), true);
-        assert_eq!(parse_bool("yes").unwrap(), true);
-        assert_eq!(parse_bool("YES").unwrap(), true);
-        assert_eq!(parse_bool("y").unwrap(), true);
-        assert_eq!(parse_bool("Y").unwrap(), true);
-        assert_eq!(parse_bool("1").unwrap(), true);
-        assert_eq!(parse_bool("on").unwrap(), true);
-        assert_eq!(parse_bool("ON").unwrap(), true);
+        assert!(parse_bool("true").unwrap());
+        assert!(parse_bool("True").unwrap());
+        assert!(parse_bool("TRUE").unwrap());
+        assert!(parse_bool("yes").unwrap());
+        assert!(parse_bool("YES").unwrap());
+        assert!(parse_bool("y").unwrap());
+        assert!(parse_bool("Y").unwrap());
+        assert!(parse_bool("1").unwrap());
+        assert!(parse_bool("on").unwrap());
+        assert!(parse_bool("ON").unwrap());
     }
 
     #[test]
     fn test_parse_bool_false_variants() {
         // All false variants
-        assert_eq!(parse_bool("false").unwrap(), false);
-        assert_eq!(parse_bool("False").unwrap(), false);
-        assert_eq!(parse_bool("FALSE").unwrap(), false);
-        assert_eq!(parse_bool("no").unwrap(), false);
-        assert_eq!(parse_bool("NO").unwrap(), false);
-        assert_eq!(parse_bool("n").unwrap(), false);
-        assert_eq!(parse_bool("N").unwrap(), false);
-        assert_eq!(parse_bool("0").unwrap(), false);
-        assert_eq!(parse_bool("off").unwrap(), false);
-        assert_eq!(parse_bool("OFF").unwrap(), false);
+        assert!(!parse_bool("false").unwrap());
+        assert!(!parse_bool("False").unwrap());
+        assert!(!parse_bool("FALSE").unwrap());
+        assert!(!parse_bool("no").unwrap());
+        assert!(!parse_bool("NO").unwrap());
+        assert!(!parse_bool("n").unwrap());
+        assert!(!parse_bool("N").unwrap());
+        assert!(!parse_bool("0").unwrap());
+        assert!(!parse_bool("off").unwrap());
+        assert!(!parse_bool("OFF").unwrap());
     }
 
     #[test]
     fn test_parse_bool_with_whitespace() {
-        assert_eq!(parse_bool("  true  ").unwrap(), true);
-        assert_eq!(parse_bool("\tfalse\n").unwrap(), false);
+        assert!(parse_bool("  true  ").unwrap());
+        assert!(!parse_bool("\tfalse\n").unwrap());
     }
 
     #[test]

--- a/src/plugin/builtin/config.rs
+++ b/src/plugin/builtin/config.rs
@@ -1,0 +1,293 @@
+//! Standalone `ConfigPlugin` (feature-gated).
+//!
+//! Contributes two handlers over the application's own loaded
+//! [`CommandsConfig`] — `config_show` (display it as YAML) and
+//! `config_validate` (re-run schema validation without restarting the
+//! application) — following the same `Option<CommandsConfig>`
+//! attachment pattern as [`SystemPlugin::with_config`][crate::plugin::system::SystemPlugin::with_config].
+//!
+//! Only available with the `config-plugin` feature.
+
+use crate::config::{validate_config, CommandsConfig};
+use crate::context::ExecutionContext;
+use crate::executor::CommandHandler;
+use crate::parser::ParsedArgs;
+use crate::plugin::Plugin;
+use crate::Result;
+
+/// Standalone plugin providing `config` commands: `show` and `validate`.
+///
+/// Both handlers operate on the same [`CommandsConfig`] the application
+/// attaches via [`with_config`][Self::with_config] — there is no
+/// separate config-loading logic here, only display and re-validation
+/// of what the application already loaded.
+///
+/// # YAML config
+///
+/// ```yaml
+/// commands:
+///   - name: config-show
+///     implementation: config_show
+///     description: "Show the loaded configuration"
+///     required: false
+///     arguments: []
+///     options: []
+///   - name: config-validate
+///     implementation: config_validate
+///     description: "Re-validate the loaded configuration"
+///     required: false
+///     arguments: []
+///     options: []
+/// ```
+///
+/// # Example
+///
+/// ```
+/// use dynamic_cli::plugin::{ConfigPlugin, Plugin};
+///
+/// let plugin = ConfigPlugin::new();
+/// assert_eq!(plugin.name(), "config");
+///
+/// let handlers = plugin.handlers();
+/// assert_eq!(handlers.len(), 2);
+/// ```
+pub struct ConfigPlugin {
+    /// The application's own config, attached via [`with_config`][Self::with_config].
+    config: Option<CommandsConfig>,
+}
+
+impl ConfigPlugin {
+    /// Create a new `ConfigPlugin` with no config attached.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use dynamic_cli::plugin::{ConfigPlugin, Plugin};
+    ///
+    /// let plugin = ConfigPlugin::new();
+    /// assert_eq!(plugin.name(), "config");
+    /// ```
+    pub fn new() -> Self {
+        Self { config: None }
+    }
+
+    /// Attach the application's config so `config_show`/`config_validate`
+    /// have something to operate on.
+    ///
+    /// Call this yourself before
+    /// [`register_plugin`][crate::builder::CliBuilder::register_plugin] —
+    /// `CliBuilder::build()` does not attach config to plugins on its own.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use dynamic_cli::plugin::{ConfigPlugin, Plugin};
+    /// use dynamic_cli::config::schema::{CommandsConfig, Metadata};
+    ///
+    /// let config = CommandsConfig {
+    ///     metadata: Metadata {
+    ///         version: "1.0.0".to_string(),
+    ///         prompt: "myapp".to_string(),
+    ///         prompt_suffix: " > ".to_string(),
+    ///     },
+    ///     commands: vec![],
+    ///     global_options: vec![],
+    /// };
+    ///
+    /// let plugin = ConfigPlugin::new().with_config(config);
+    /// assert_eq!(plugin.name(), "config");
+    /// ```
+    pub fn with_config(mut self, config: CommandsConfig) -> Self {
+        self.config = Some(config);
+        self
+    }
+}
+
+impl Default for ConfigPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Plugin for ConfigPlugin {
+    fn name(&self) -> &str {
+        "config"
+    }
+
+    fn version(&self) -> &str {
+        env!("CARGO_PKG_VERSION")
+    }
+
+    fn description(&self) -> &str {
+        "Show/validate the loaded YAML config, without restarting (feature-gated, #47)"
+    }
+
+    fn handlers(&self) -> Vec<(String, Box<dyn CommandHandler>)> {
+        vec![
+            (
+                "config_show".to_string(),
+                Box::new(ConfigShowHandler {
+                    config: self.config.clone(),
+                }),
+            ),
+            (
+                "config_validate".to_string(),
+                Box::new(ConfigValidateHandler {
+                    config: self.config.clone(),
+                }),
+            ),
+        ]
+    }
+}
+
+/// Handler for `config_show` — prints the loaded config as YAML.
+struct ConfigShowHandler {
+    config: Option<CommandsConfig>,
+}
+
+impl CommandHandler for ConfigShowHandler {
+    fn execute(&self, _ctx: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
+        match &self.config {
+            Some(cfg) => match serde_yaml::to_string(cfg) {
+                Ok(yaml) => println!("{yaml}"),
+                Err(e) => println!("Failed to render config as YAML: {e}"),
+            },
+            None => println!("No configuration attached to this application."),
+        }
+        Ok(())
+    }
+}
+
+/// Handler for `config_validate` — re-runs schema validation on the
+/// loaded config, without restarting the application.
+struct ConfigValidateHandler {
+    config: Option<CommandsConfig>,
+}
+
+impl CommandHandler for ConfigValidateHandler {
+    fn execute(&self, _ctx: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
+        match &self.config {
+            Some(cfg) => match validate_config(cfg) {
+                Ok(()) => println!("Configuration is valid."),
+                Err(e) => println!("Configuration is invalid: {e}"),
+            },
+            None => println!("No configuration attached to this application."),
+        }
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::schema::Metadata;
+    use std::any::Any;
+
+    #[derive(Default)]
+    struct TestContext;
+
+    impl ExecutionContext for TestContext {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+        fn as_any_mut(&mut self) -> &mut dyn Any {
+            self
+        }
+    }
+
+    fn test_config() -> CommandsConfig {
+        CommandsConfig {
+            metadata: Metadata {
+                version: "2.0.0".to_string(),
+                prompt: "testapp".to_string(),
+                prompt_suffix: " > ".to_string(),
+            },
+            commands: vec![],
+            global_options: vec![],
+        }
+    }
+
+    #[test]
+    fn test_config_plugin_metadata() {
+        let p = ConfigPlugin::new();
+        assert_eq!(p.name(), "config");
+        assert!(!p.version().is_empty());
+        assert!(!p.description().is_empty());
+    }
+
+    #[test]
+    fn test_config_plugin_default() {
+        let p = ConfigPlugin::default();
+        assert_eq!(p.name(), "config");
+    }
+
+    #[test]
+    fn test_config_plugin_handler_names() {
+        let handlers = ConfigPlugin::new().handlers();
+        assert_eq!(handlers.len(), 2);
+        let names: Vec<&str> = handlers.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(names.contains(&"config_show"));
+        assert!(names.contains(&"config_validate"));
+    }
+
+    #[test]
+    fn test_config_plugin_with_config() {
+        let plugin = ConfigPlugin::new().with_config(test_config());
+        assert!(plugin.config.is_some());
+        assert_eq!(plugin.config.unwrap().metadata.version, "2.0.0");
+    }
+
+    #[test]
+    fn test_config_show_executes_with_config() {
+        let plugin = ConfigPlugin::new().with_config(test_config());
+        let handlers = plugin.handlers();
+        let (name, handler) = &handlers[0];
+        assert_eq!(name, "config_show");
+        let mut ctx = TestContext;
+        assert!(handler
+            .execute(&mut ctx, &ParsedArgs::from_scalars(Default::default()))
+            .is_ok());
+    }
+
+    #[test]
+    fn test_config_show_executes_without_config() {
+        let handlers = ConfigPlugin::new().handlers();
+        let (_, handler) = &handlers[0];
+        let mut ctx = TestContext;
+        assert!(handler
+            .execute(&mut ctx, &ParsedArgs::from_scalars(Default::default()))
+            .is_ok());
+    }
+
+    #[test]
+    fn test_config_validate_executes_with_valid_config() {
+        let plugin = ConfigPlugin::new().with_config(test_config());
+        let handlers = plugin.handlers();
+        let (name, handler) = &handlers[1];
+        assert_eq!(name, "config_validate");
+        let mut ctx = TestContext;
+        assert!(handler
+            .execute(&mut ctx, &ParsedArgs::from_scalars(Default::default()))
+            .is_ok());
+    }
+
+    #[test]
+    fn test_config_validate_executes_without_config() {
+        let handlers = ConfigPlugin::new().handlers();
+        let (_, handler) = &handlers[1];
+        let mut ctx = TestContext;
+        assert!(handler
+            .execute(&mut ctx, &ParsedArgs::from_scalars(Default::default()))
+            .is_ok());
+    }
+
+    #[test]
+    fn test_config_plugin_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>(_: T) {}
+        assert_send_sync(ConfigPlugin::new());
+    }
+}

--- a/src/plugin/builtin/env.rs
+++ b/src/plugin/builtin/env.rs
@@ -1,0 +1,236 @@
+//! Standalone `EnvPlugin` (feature-gated).
+//!
+//! Displays environment variables, with sensitive-looking ones excluded
+//! by default — never a raw `std::env::vars()` dump. Only available with
+//! the `env-plugin` feature.
+//!
+//! # Filtering rule
+//!
+//! Unlike [`ArgumentDefinition::secure`][crate::config::schema::ArgumentDefinition]
+//! (DD-023), which relies on an explicit `secure: true` opt-in on a
+//! config-declared argument, environment variables have no such upfront
+//! declaration — the set of names is arbitrary and unknown ahead of
+//! time. An allow-list is therefore not viable here; this plugin instead
+//! uses a **deny-list of case-insensitive substrings** applied to each
+//! variable's name:
+//!
+//! ```text
+//! SECRET, TOKEN, KEY, PASS, CREDENTIAL, AUTH, PRIVATE
+//! ```
+//!
+//! Any variable whose name contains one of these substrings (case
+//! folded) is hidden — its value is never printed, never included in
+//! output, only counted. This is a heuristic, not a guarantee: an
+//! oddly-named secret can still slip through. See [`is_sensitive_name`]
+//! if a custom list is needed.
+
+use crate::context::ExecutionContext;
+use crate::executor::CommandHandler;
+use crate::parser::ParsedArgs;
+use crate::plugin::Plugin;
+use crate::Result;
+
+/// Case-insensitive substrings that mark an environment variable name as
+/// sensitive. See the module-level docs for the rationale.
+const SENSITIVE_NAME_SUBSTRINGS: &[&str] = &[
+    "SECRET",
+    "TOKEN",
+    "KEY",
+    "PASS",
+    "CREDENTIAL",
+    "AUTH",
+    "PRIVATE",
+];
+
+/// Returns `true` if `name` looks sensitive under the deny-list rule
+/// documented at the module level.
+fn is_sensitive_name(name: &str) -> bool {
+    let upper = name.to_uppercase();
+    SENSITIVE_NAME_SUBSTRINGS
+        .iter()
+        .any(|needle| upper.contains(needle))
+}
+
+/// Standalone plugin providing a single `env` command.
+///
+/// Prints environment variable names and values, skipping any name that
+/// looks sensitive (see the module-level filtering rule). The variable
+/// *name* itself is always shown for hidden entries — only its value is
+/// withheld — so the count and presence of hidden variables stays
+/// visible without leaking their contents.
+///
+/// # YAML config
+///
+/// ```yaml
+/// commands:
+///   - name: env
+///     implementation: env_show
+///     description: "Show environment variables (sensitive ones hidden)"
+///     required: false
+///     arguments: []
+///     options: []
+/// ```
+///
+/// # Example
+///
+/// ```
+/// use dynamic_cli::plugin::{EnvPlugin, Plugin};
+///
+/// let plugin = EnvPlugin::new();
+/// assert_eq!(plugin.name(), "env");
+///
+/// let handlers = plugin.handlers();
+/// assert_eq!(handlers.len(), 1);
+/// assert_eq!(handlers[0].0, "env_show");
+/// ```
+pub struct EnvPlugin;
+
+impl EnvPlugin {
+    /// Create a new `EnvPlugin`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use dynamic_cli::plugin::{EnvPlugin, Plugin};
+    ///
+    /// let plugin = EnvPlugin::new();
+    /// assert_eq!(plugin.name(), "env");
+    /// ```
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for EnvPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Plugin for EnvPlugin {
+    fn name(&self) -> &str {
+        "env"
+    }
+
+    fn version(&self) -> &str {
+        env!("CARGO_PKG_VERSION")
+    }
+
+    fn description(&self) -> &str {
+        "Filtered environment variable display (feature-gated, #46)"
+    }
+
+    fn handlers(&self) -> Vec<(String, Box<dyn CommandHandler>)> {
+        vec![("env_show".to_string(), Box::new(EnvShowHandler))]
+    }
+}
+
+/// Handler for `env_show` — prints environment variables, hiding
+/// sensitive-looking ones. See the module-level filtering rule.
+struct EnvShowHandler;
+
+impl CommandHandler for EnvShowHandler {
+    fn execute(&self, _ctx: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
+        let mut vars: Vec<(String, String)> = std::env::vars().collect();
+        vars.sort_by(|a, b| a.0.cmp(&b.0));
+
+        let mut hidden_count = 0usize;
+
+        for (name, value) in &vars {
+            if is_sensitive_name(name) {
+                hidden_count += 1;
+                println!("{name} = <hidden>");
+            } else {
+                println!("{name} = {value}");
+            }
+        }
+
+        if hidden_count > 0 {
+            println!("\n{hidden_count} variable(s) hidden (name looked sensitive)");
+        }
+
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::any::Any;
+
+    #[derive(Default)]
+    struct TestContext;
+
+    impl ExecutionContext for TestContext {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+        fn as_any_mut(&mut self) -> &mut dyn Any {
+            self
+        }
+    }
+
+    #[test]
+    fn test_env_plugin_metadata() {
+        let p = EnvPlugin::new();
+        assert_eq!(p.name(), "env");
+        assert!(!p.version().is_empty());
+        assert!(!p.description().is_empty());
+    }
+
+    #[test]
+    fn test_env_plugin_default() {
+        let p = EnvPlugin::default();
+        assert_eq!(p.name(), "env");
+    }
+
+    #[test]
+    fn test_env_plugin_handler_name() {
+        let handlers = EnvPlugin::new().handlers();
+        assert_eq!(handlers.len(), 1);
+        assert_eq!(handlers[0].0, "env_show");
+    }
+
+    #[test]
+    fn test_env_handler_executes() {
+        let handlers = EnvPlugin::new().handlers();
+        let (_, handler) = &handlers[0];
+        let mut ctx = TestContext;
+        assert!(handler
+            .execute(&mut ctx, &ParsedArgs::from_scalars(Default::default()))
+            .is_ok());
+    }
+
+    #[test]
+    fn test_env_plugin_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>(_: T) {}
+        assert_send_sync(EnvPlugin::new());
+    }
+
+    #[test]
+    fn test_is_sensitive_name_matches_expected_patterns() {
+        assert!(is_sensitive_name("API_SECRET"));
+        assert!(is_sensitive_name("AWS_ACCESS_KEY_ID"));
+        assert!(is_sensitive_name("DATABASE_PASSWORD"));
+        assert!(is_sensitive_name("GITHUB_TOKEN"));
+        assert!(is_sensitive_name("MY_APP_CREDENTIAL"));
+        assert!(is_sensitive_name("BASIC_AUTH_HEADER"));
+        assert!(is_sensitive_name("SSH_PRIVATE_KEY_PATH"));
+        // Case-insensitivity
+        assert!(is_sensitive_name("api_secret"));
+        assert!(is_sensitive_name("Api_Secret"));
+    }
+
+    #[test]
+    fn test_is_sensitive_name_leaves_ordinary_vars_alone() {
+        assert!(!is_sensitive_name("PATH"));
+        assert!(!is_sensitive_name("HOME"));
+        assert!(!is_sensitive_name("LANG"));
+        assert!(!is_sensitive_name("EDITOR"));
+        assert!(!is_sensitive_name("RUST_LOG"));
+    }
+}

--- a/src/plugin/builtin/exit.rs
+++ b/src/plugin/builtin/exit.rs
@@ -1,0 +1,223 @@
+//! Standalone `ExitPlugin`.
+//!
+//! Contributes the same `system_exit` handler as [`SystemPlugin`], reusing
+//! [`SystemExitHandler`]'s logic internally — no duplicated logic (#44 /
+//! DD-025). Supports the same shutdown-callback mechanism as
+//! [`SystemPlugin::with_exit_fn`][crate::builtin::system::SystemPlugin::with_exit_fn].
+//!
+//! [`SystemPlugin`]: crate::builtin::system::SystemPlugin
+//! [`SystemExitHandler`]: crate::builtin::system::SystemExitHandler
+
+use crate::executor::CommandHandler;
+use crate::plugin::system::SystemExitHandler;
+use crate::plugin::Plugin;
+use std::sync::Arc;
+
+/// Standalone builtin providing only the `exit` command.
+///
+/// Use this instead of [`SystemPlugin`][crate::builtin::system::SystemPlugin]
+/// when an application wants `exit` without also registering `help` and
+/// `version`.
+///
+/// # Shutdown callback
+///
+/// Same mechanism as `SystemPlugin`: the callback runs **before** the
+/// process exits. The default callback calls `std::process::exit(0)`
+/// directly.
+///
+/// ```no_run
+/// use dynamic_cli::plugin::ExitPlugin;
+///
+/// let builtin = ExitPlugin::new()
+///     .with_exit_fn(|| {
+///         eprintln!("Goodbye.");
+///         std::process::exit(0);
+///     });
+/// ```
+///
+/// # YAML config
+///
+/// ```yaml
+/// commands:
+///   - name: exit
+///     implementation: system_exit
+///     description: "Exit the application"
+///     aliases: ["quit", "q"]
+///     required: false
+///     arguments: []
+///     options: []
+/// ```
+///
+/// # Example
+///
+/// ```
+/// use dynamic_cli::plugin::{ExitPlugin, Plugin};
+///
+/// let builtin = ExitPlugin::new();
+/// assert_eq!(builtin.name(), "exit");
+///
+/// let handlers = builtin.handlers();
+/// assert_eq!(handlers.len(), 1);
+/// assert_eq!(handlers[0].0, "system_exit");
+/// ```
+pub struct ExitPlugin {
+    /// Shutdown callback invoked by `system_exit`.
+    ///
+    /// Defaults to `|| std::process::exit(0)`.
+    /// Override with [`ExitPlugin::with_exit_fn`] for a clean shutdown
+    /// sequence (flush buffers, close connections, save state, etc.).
+    exit_fn: Arc<dyn Fn() + Send + Sync>,
+}
+
+impl ExitPlugin {
+    /// Create a new `ExitPlugin` with the default shutdown behaviour.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use dynamic_cli::plugin::{ExitPlugin, Plugin};
+    ///
+    /// let builtin = ExitPlugin::new();
+    /// assert_eq!(builtin.name(), "exit");
+    /// ```
+    pub fn new() -> Self {
+        Self {
+            exit_fn: Arc::new(|| std::process::exit(0)),
+        }
+    }
+
+    /// Supply a custom shutdown callback for `system_exit`.
+    ///
+    /// The callback must be `Fn() + Send + Sync + 'static`.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use dynamic_cli::plugin::ExitPlugin;
+    ///
+    /// let builtin = ExitPlugin::new()
+    ///     .with_exit_fn(|| {
+    ///         eprintln!("Saving session…");
+    ///         std::process::exit(0);
+    ///     });
+    /// ```
+    pub fn with_exit_fn<F>(mut self, f: F) -> Self
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
+        self.exit_fn = Arc::new(f);
+        self
+    }
+}
+
+impl Default for ExitPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Plugin for ExitPlugin {
+    fn name(&self) -> &str {
+        "exit"
+    }
+
+    fn version(&self) -> &str {
+        env!("CARGO_PKG_VERSION")
+    }
+
+    fn description(&self) -> &str {
+        "Standalone exit command (split out of SystemPlugin, #44)"
+    }
+
+    fn handlers(&self) -> Vec<(String, Box<dyn CommandHandler>)> {
+        vec![(
+            "system_exit".to_string(),
+            Box::new(SystemExitHandler::new(self.exit_fn.clone())),
+        )]
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::ExecutionContext;
+    use crate::parser::ParsedArgs;
+    use std::any::Any;
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    #[derive(Default)]
+    struct TestContext;
+
+    impl ExecutionContext for TestContext {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+        fn as_any_mut(&mut self) -> &mut dyn Any {
+            self
+        }
+    }
+
+    #[test]
+    fn test_exit_plugin_metadata() {
+        let p = ExitPlugin::new();
+        assert_eq!(p.name(), "exit");
+        assert!(!p.version().is_empty());
+        assert!(!p.description().is_empty());
+    }
+
+    #[test]
+    fn test_exit_plugin_default() {
+        let p = ExitPlugin::default();
+        assert_eq!(p.name(), "exit");
+    }
+
+    #[test]
+    fn test_exit_plugin_handler_name() {
+        let handlers = ExitPlugin::new().handlers();
+        assert_eq!(handlers.len(), 1);
+        assert_eq!(handlers[0].0, "system_exit");
+    }
+
+    #[test]
+    fn test_exit_default_callback_is_set() {
+        // The default callback (process::exit) cannot be invoked in tests;
+        // only check that the builtin builds and exposes the handler.
+        let plugin = ExitPlugin::new();
+        let handlers = plugin.handlers();
+        assert_eq!(handlers.len(), 1);
+    }
+
+    #[test]
+    fn test_exit_custom_callback_invoked() {
+        let called = Arc::new(AtomicBool::new(false));
+        let called_clone = called.clone();
+
+        let plugin = ExitPlugin::new().with_exit_fn(move || {
+            called_clone.store(true, Ordering::SeqCst);
+            // Does NOT call std::process::exit — safe in tests.
+        });
+
+        let handlers = plugin.handlers();
+        let (_, handler) = &handlers[0];
+
+        let mut ctx = TestContext;
+        let result = handler.execute(&mut ctx, &ParsedArgs::from_scalars(HashMap::new()));
+
+        assert!(result.is_ok());
+        assert!(
+            called.load(Ordering::SeqCst),
+            "shutdown callback was not invoked"
+        );
+    }
+
+    #[test]
+    fn test_exit_plugin_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>(_: T) {}
+        assert_send_sync(ExitPlugin::new().with_exit_fn(|| {}));
+    }
+}

--- a/src/plugin/builtin/help.rs
+++ b/src/plugin/builtin/help.rs
@@ -1,0 +1,215 @@
+//! Standalone `HelpPlugin`.
+//!
+//! Contributes the same `system_help` handler as [`SystemPlugin`], reusing
+//! [`SystemHelpHandler`]'s logic internally — no duplicated logic (#44 /
+//! DD-025).
+//!
+//! [`SystemPlugin`]: crate::plugin::system::SystemPlugin
+//! [`SystemHelpHandler`]: crate::plugin::system::SystemHelpHandler
+
+use crate::config::schema::CommandsConfig;
+use crate::executor::CommandHandler;
+use crate::plugin::system::SystemHelpHandler;
+use crate::plugin::Plugin;
+
+/// Standalone builtin providing only the `help` command.
+///
+/// Use this instead of [`SystemPlugin`][crate::builtin::system::SystemPlugin]
+/// when an application wants `help` without also registering `version` and
+/// `exit`.
+///
+/// # YAML config
+///
+/// ```yaml
+/// commands:
+///   - name: help
+///     implementation: system_help
+///     description: "Show help"
+///     aliases: ["h", "?"]
+///     required: false
+///     arguments: []
+///     options: []
+/// ```
+///
+/// # Example
+///
+/// ```
+/// use dynamic_cli::plugin::{HelpPlugin, Plugin};
+///
+/// let builtin = HelpPlugin::new();
+/// assert_eq!(builtin.name(), "help");
+///
+/// let handlers = builtin.handlers();
+/// assert_eq!(handlers.len(), 1);
+/// assert_eq!(handlers[0].0, "system_help");
+/// ```
+pub struct HelpPlugin {
+    /// Application config, needed to render help content.
+    config: Option<CommandsConfig>,
+}
+
+impl HelpPlugin {
+    /// Create a new `HelpPlugin` with no config attached.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use dynamic_cli::plugin::{HelpPlugin, Plugin};
+    ///
+    /// let builtin = HelpPlugin::new();
+    /// assert_eq!(builtin.name(), "help");
+    /// ```
+    pub fn new() -> Self {
+        Self { config: None }
+    }
+
+    /// Attach a config so the handler can render app/command help.
+    ///
+    /// Call this yourself before
+    /// [`register_plugin`][crate::builder::CliBuilder::register_plugin] —
+    /// `CliBuilder::build()` does not attach config to plugins on its own.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use dynamic_cli::plugin::{HelpPlugin, Plugin};
+    /// use dynamic_cli::config::schema::{CommandsConfig, Metadata};
+    ///
+    /// let config = CommandsConfig {
+    ///     metadata: Metadata {
+    ///         version: "1.0.0".to_string(),
+    ///         prompt: "myapp".to_string(),
+    ///         prompt_suffix: " > ".to_string(),
+    ///     },
+    ///     commands: vec![],
+    ///     global_options: vec![],
+    /// };
+    ///
+    /// let builtin = HelpPlugin::new().with_config(config);
+    /// assert_eq!(builtin.name(), "help");
+    /// ```
+    pub fn with_config(mut self, config: CommandsConfig) -> Self {
+        self.config = Some(config);
+        self
+    }
+}
+
+impl Default for HelpPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Plugin for HelpPlugin {
+    fn name(&self) -> &str {
+        "help"
+    }
+
+    fn version(&self) -> &str {
+        env!("CARGO_PKG_VERSION")
+    }
+
+    fn description(&self) -> &str {
+        "Standalone help command (split out of SystemPlugin, #44)"
+    }
+
+    fn handlers(&self) -> Vec<(String, Box<dyn CommandHandler>)> {
+        vec![(
+            "system_help".to_string(),
+            Box::new(SystemHelpHandler::new(self.config.clone())),
+        )]
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::schema::{CommandsConfig, Metadata};
+    use crate::context::ExecutionContext;
+    use crate::parser::ParsedArgs;
+    use std::any::Any;
+    use std::collections::HashMap;
+
+    #[derive(Default)]
+    struct TestContext;
+
+    impl ExecutionContext for TestContext {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+        fn as_any_mut(&mut self) -> &mut dyn Any {
+            self
+        }
+    }
+
+    fn test_config() -> CommandsConfig {
+        CommandsConfig {
+            metadata: Metadata {
+                version: "2.0.0".to_string(),
+                prompt: "testapp".to_string(),
+                prompt_suffix: " > ".to_string(),
+            },
+            commands: vec![],
+            global_options: vec![],
+        }
+    }
+
+    #[test]
+    fn test_help_plugin_metadata() {
+        let p = HelpPlugin::new();
+        assert_eq!(p.name(), "help");
+        assert!(!p.version().is_empty());
+        assert!(!p.description().is_empty());
+    }
+
+    #[test]
+    fn test_help_plugin_default() {
+        let p = HelpPlugin::default();
+        assert_eq!(p.name(), "help");
+    }
+
+    #[test]
+    fn test_help_plugin_handler_name() {
+        let handlers = HelpPlugin::new().handlers();
+        assert_eq!(handlers.len(), 1);
+        assert_eq!(handlers[0].0, "system_help");
+    }
+
+    #[test]
+    fn test_help_plugin_with_config() {
+        let plugin = HelpPlugin::new().with_config(test_config());
+        assert!(plugin.config.is_some());
+        assert_eq!(plugin.config.unwrap().metadata.version, "2.0.0");
+    }
+
+    #[test]
+    fn test_help_handler_executes_with_config() {
+        let plugin = HelpPlugin::new().with_config(test_config());
+        let handlers = plugin.handlers();
+        let (_, handler) = &handlers[0];
+        let mut ctx = TestContext;
+        assert!(handler
+            .execute(&mut ctx, &ParsedArgs::from_scalars(HashMap::new()))
+            .is_ok());
+    }
+
+    #[test]
+    fn test_help_handler_executes_without_config() {
+        let handlers = HelpPlugin::new().handlers();
+        let (_, handler) = &handlers[0];
+        let mut ctx = TestContext;
+        assert!(handler
+            .execute(&mut ctx, &ParsedArgs::from_scalars(HashMap::new()))
+            .is_ok());
+    }
+
+    #[test]
+    fn test_help_plugin_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>(_: T) {}
+        assert_send_sync(HelpPlugin::new());
+    }
+}

--- a/src/plugin/builtin/mod.rs
+++ b/src/plugin/builtin/mod.rs
@@ -1,0 +1,44 @@
+//! Standalone, single-command plugins.
+//!
+//! `SystemPlugin` (in [`crate::builtin::system`]) bundles `help`, `version`,
+//! and `exit` into a single builtin. This module offers the same three
+//! commands as **independent** plugins — [`HelpPlugin`], [`VersionPlugin`],
+//! [`ExitPlugin`] — for applications that want to compose only the ones
+//! they need (e.g. `version` alone, without `help`/`exit`).
+//!
+//! # Relationship to `SystemPlugin`
+//!
+//! Each builtin here reuses the exact same handler logic as its
+//! `SystemPlugin` counterpart (`SystemHelpHandler`, `SystemVersionHandler`,
+//! `SystemExitHandler` in [`crate::builtin::system`]) — this is a pure
+//! internal refactor (#44 / DD-025). `SystemPlugin`'s public API, its
+//! `handlers()` output, and its existing test suite are unaffected.
+//!
+//! | Plugin          | Implementation name | Behaviour                                   |
+//! |------------------|---------------------|----------------------------------------------|
+//! | [`HelpPlugin`]    | `system_help`       | Same as `SystemPlugin`'s `system_help`        |
+//! | [`VersionPlugin`] | `system_version`    | Same as `SystemPlugin`'s `system_version`     |
+//! | [`ExitPlugin`]    | `system_exit`       | Same as `SystemPlugin`'s `system_exit`        |
+//!
+//! Implementation names are unchanged, so existing YAML configs that
+//! reference `system_help` / `system_version` / `system_exit` keep working
+//! whether the commands are wired through `SystemPlugin` or through these
+//! granular plugins.
+//!
+//! # Example
+//!
+//! ```
+//! use dynamic_cli::plugin::{Plugin, VersionPlugin};
+//!
+//! // Register only `version`, without `help` or `exit`.
+//! let builtin = VersionPlugin::new();
+//! assert_eq!(builtin.handlers().len(), 1);
+//! ```
+
+mod exit;
+mod help;
+mod version;
+
+pub use exit::ExitPlugin;
+pub use help::HelpPlugin;
+pub use version::VersionPlugin;

--- a/src/plugin/builtin/mod.rs
+++ b/src/plugin/builtin/mod.rs
@@ -1,16 +1,16 @@
 //! Standalone, single-command plugins.
 //!
-//! `SystemPlugin` (in [`crate::builtin::system`]) bundles `help`, `version`,
-//! and `exit` into a single builtin. This module offers the same three
+//! `SystemPlugin` (in [`crate::plugin::system`]) bundles `help`, `version`,
+//! and `exit` into a single plugin. This module offers the same three
 //! commands as **independent** plugins — [`HelpPlugin`], [`VersionPlugin`],
 //! [`ExitPlugin`] — for applications that want to compose only the ones
 //! they need (e.g. `version` alone, without `help`/`exit`).
 //!
 //! # Relationship to `SystemPlugin`
 //!
-//! Each builtin here reuses the exact same handler logic as its
+//! Each plugin here reuses the exact same handler logic as its
 //! `SystemPlugin` counterpart (`SystemHelpHandler`, `SystemVersionHandler`,
-//! `SystemExitHandler` in [`crate::builtin::system`]) — this is a pure
+//! `SystemExitHandler` in [`crate::plugin::system`]) — this is a pure
 //! internal refactor (#44 / DD-025). `SystemPlugin`'s public API, its
 //! `handlers()` output, and its existing test suite are unaffected.
 //!
@@ -31,14 +31,32 @@
 //! use dynamic_cli::plugin::{Plugin, VersionPlugin};
 //!
 //! // Register only `version`, without `help` or `exit`.
-//! let builtin = VersionPlugin::new();
-//! assert_eq!(builtin.handlers().len(), 1);
+//! let plugin = VersionPlugin::new();
+//! assert_eq!(plugin.handlers().len(), 1);
 //! ```
 
 mod exit;
 mod help;
 mod version;
 
+#[cfg(feature = "sysinfo-plugin")]
+mod sysinfo;
+
+#[cfg(feature = "env-plugin")]
+mod env;
+
+#[cfg(feature = "config-plugin")]
+mod config;
+
 pub use exit::ExitPlugin;
 pub use help::HelpPlugin;
 pub use version::VersionPlugin;
+
+#[cfg(feature = "sysinfo-plugin")]
+pub use sysinfo::SysInfoPlugin;
+
+#[cfg(feature = "env-plugin")]
+pub use env::EnvPlugin;
+
+#[cfg(feature = "config-plugin")]
+pub use config::ConfigPlugin;

--- a/src/plugin/builtin/sysinfo.rs
+++ b/src/plugin/builtin/sysinfo.rs
@@ -1,0 +1,166 @@
+//! Standalone `SysInfoPlugin` (feature-gated).
+//!
+//! Prints basic runtime/OS information — operating system, architecture,
+//! and available parallelism — using only `std`. No new dependency: this
+//! is deliberately a minimal baseline (#45 / DD-025). A richer variant
+//! backed by the `sysinfo` crate is out of scope here; if pursued later,
+//! it stays under this same `sysinfo-plugin` feature flag rather than a
+//! second one, per the uniform feature-flag policy decided in the DD-025
+//! triage.
+//!
+//! Only available with the `sysinfo-plugin` feature.
+
+use crate::context::ExecutionContext;
+use crate::executor::CommandHandler;
+use crate::parser::ParsedArgs;
+use crate::plugin::Plugin;
+use crate::Result;
+
+/// Standalone plugin providing a single `sysinfo` command.
+///
+/// Reports the operating system, CPU architecture, and available
+/// parallelism (`std::thread::available_parallelism()`) — everything
+/// `std` can report without a third-party crate.
+///
+/// # YAML config
+///
+/// ```yaml
+/// commands:
+///   - name: sysinfo
+///     implementation: sysinfo_show
+///     description: "Show runtime/OS information"
+///     required: false
+///     arguments: []
+///     options: []
+/// ```
+///
+/// # Example
+///
+/// ```
+/// use dynamic_cli::plugin::{Plugin, SysInfoPlugin};
+///
+/// let plugin = SysInfoPlugin::new();
+/// assert_eq!(plugin.name(), "sysinfo");
+///
+/// let handlers = plugin.handlers();
+/// assert_eq!(handlers.len(), 1);
+/// assert_eq!(handlers[0].0, "sysinfo_show");
+/// ```
+pub struct SysInfoPlugin;
+
+impl SysInfoPlugin {
+    /// Create a new `SysInfoPlugin`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use dynamic_cli::plugin::{Plugin, SysInfoPlugin};
+    ///
+    /// let plugin = SysInfoPlugin::new();
+    /// assert_eq!(plugin.name(), "sysinfo");
+    /// ```
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for SysInfoPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Plugin for SysInfoPlugin {
+    fn name(&self) -> &str {
+        "sysinfo"
+    }
+
+    fn version(&self) -> &str {
+        env!("CARGO_PKG_VERSION")
+    }
+
+    fn description(&self) -> &str {
+        "Runtime/OS introspection (std-only baseline, feature-gated, #45)"
+    }
+
+    fn handlers(&self) -> Vec<(String, Box<dyn CommandHandler>)> {
+        vec![("sysinfo_show".to_string(), Box::new(SysInfoShowHandler))]
+    }
+}
+
+/// Handler for `sysinfo_show` — prints OS, architecture, and available
+/// parallelism.
+struct SysInfoShowHandler;
+
+impl CommandHandler for SysInfoShowHandler {
+    fn execute(&self, _ctx: &mut dyn ExecutionContext, _args: &ParsedArgs) -> Result<()> {
+        let parallelism = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1);
+
+        println!("OS:                  {}", std::env::consts::OS);
+        println!("Architecture:        {}", std::env::consts::ARCH);
+        println!("Available parallelism: {}", parallelism);
+
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::any::Any;
+
+    #[derive(Default)]
+    struct TestContext;
+
+    impl ExecutionContext for TestContext {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+        fn as_any_mut(&mut self) -> &mut dyn Any {
+            self
+        }
+    }
+
+    #[test]
+    fn test_sysinfo_plugin_metadata() {
+        let p = SysInfoPlugin::new();
+        assert_eq!(p.name(), "sysinfo");
+        assert!(!p.version().is_empty());
+        assert!(!p.description().is_empty());
+    }
+
+    #[test]
+    fn test_sysinfo_plugin_default() {
+        let p = SysInfoPlugin::default();
+        assert_eq!(p.name(), "sysinfo");
+    }
+
+    #[test]
+    fn test_sysinfo_plugin_handler_name() {
+        let handlers = SysInfoPlugin::new().handlers();
+        assert_eq!(handlers.len(), 1);
+        assert_eq!(handlers[0].0, "sysinfo_show");
+    }
+
+    #[test]
+    fn test_sysinfo_handler_executes() {
+        let handlers = SysInfoPlugin::new().handlers();
+        let (_, handler) = &handlers[0];
+        let mut ctx = TestContext;
+        assert!(handler
+            .execute(&mut ctx, &ParsedArgs::from_scalars(Default::default()))
+            .is_ok());
+    }
+
+    #[test]
+    fn test_sysinfo_plugin_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>(_: T) {}
+        assert_send_sync(SysInfoPlugin::new());
+    }
+}

--- a/src/plugin/builtin/version.rs
+++ b/src/plugin/builtin/version.rs
@@ -1,0 +1,214 @@
+//! Standalone `VersionPlugin`.
+//!
+//! Contributes the same `system_version` handler as [`SystemPlugin`],
+//! reusing [`SystemVersionHandler`]'s logic internally — no duplicated
+//! logic (#44 / DD-025).
+//!
+//! [`SystemPlugin`]: crate::plugin::system::SystemPlugin
+//! [`SystemVersionHandler`]: crate::plugin::system::SystemVersionHandler
+
+use crate::config::schema::CommandsConfig;
+use crate::executor::CommandHandler;
+use crate::plugin::system::SystemVersionHandler;
+use crate::plugin::Plugin;
+
+/// Standalone builtin providing only the `version` command.
+///
+/// Use this instead of [`SystemPlugin`][crate::builtin::system::SystemPlugin]
+/// when an application wants `version` without also registering `help` and
+/// `exit`.
+///
+/// # YAML config
+///
+/// ```yaml
+/// commands:
+///   - name: version
+///     implementation: system_version
+///     description: "Show version"
+///     required: false
+///     arguments: []
+///     options: []
+/// ```
+///
+/// # Example
+///
+/// ```
+/// use dynamic_cli::plugin::{Plugin, VersionPlugin};
+///
+/// let builtin = VersionPlugin::new();
+/// assert_eq!(builtin.name(), "version");
+///
+/// let handlers = builtin.handlers();
+/// assert_eq!(handlers.len(), 1);
+/// assert_eq!(handlers[0].0, "system_version");
+/// ```
+pub struct VersionPlugin {
+    /// Application config, needed to read `metadata.version`.
+    config: Option<CommandsConfig>,
+}
+
+impl VersionPlugin {
+    /// Create a new `VersionPlugin` with no config attached.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use dynamic_cli::plugin::{Plugin, VersionPlugin};
+    ///
+    /// let builtin = VersionPlugin::new();
+    /// assert_eq!(builtin.name(), "version");
+    /// ```
+    pub fn new() -> Self {
+        Self { config: None }
+    }
+
+    /// Attach a config so the handler can read `metadata.version`.
+    ///
+    /// Call this yourself before
+    /// [`register_plugin`][crate::builder::CliBuilder::register_plugin] —
+    /// `CliBuilder::build()` does not attach config to plugins on its own.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use dynamic_cli::plugin::{Plugin, VersionPlugin};
+    /// use dynamic_cli::config::schema::{CommandsConfig, Metadata};
+    ///
+    /// let config = CommandsConfig {
+    ///     metadata: Metadata {
+    ///         version: "1.0.0".to_string(),
+    ///         prompt: "myapp".to_string(),
+    ///         prompt_suffix: " > ".to_string(),
+    ///     },
+    ///     commands: vec![],
+    ///     global_options: vec![],
+    /// };
+    ///
+    /// let builtin = VersionPlugin::new().with_config(config);
+    /// assert_eq!(builtin.name(), "version");
+    /// ```
+    pub fn with_config(mut self, config: CommandsConfig) -> Self {
+        self.config = Some(config);
+        self
+    }
+}
+
+impl Default for VersionPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Plugin for VersionPlugin {
+    fn name(&self) -> &str {
+        "version"
+    }
+
+    fn version(&self) -> &str {
+        env!("CARGO_PKG_VERSION")
+    }
+
+    fn description(&self) -> &str {
+        "Standalone version command (split out of SystemPlugin, #44)"
+    }
+
+    fn handlers(&self) -> Vec<(String, Box<dyn CommandHandler>)> {
+        vec![(
+            "system_version".to_string(),
+            Box::new(SystemVersionHandler::new(self.config.clone())),
+        )]
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::schema::{CommandsConfig, Metadata};
+    use crate::context::ExecutionContext;
+    use crate::parser::ParsedArgs;
+    use std::any::Any;
+    use std::collections::HashMap;
+
+    #[derive(Default)]
+    struct TestContext;
+
+    impl ExecutionContext for TestContext {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+        fn as_any_mut(&mut self) -> &mut dyn Any {
+            self
+        }
+    }
+
+    fn test_config() -> CommandsConfig {
+        CommandsConfig {
+            metadata: Metadata {
+                version: "2.0.0".to_string(),
+                prompt: "testapp".to_string(),
+                prompt_suffix: " > ".to_string(),
+            },
+            commands: vec![],
+            global_options: vec![],
+        }
+    }
+
+    #[test]
+    fn test_version_plugin_metadata() {
+        let p = VersionPlugin::new();
+        assert_eq!(p.name(), "version");
+        assert!(!p.version().is_empty());
+        assert!(!p.description().is_empty());
+    }
+
+    #[test]
+    fn test_version_plugin_default() {
+        let p = VersionPlugin::default();
+        assert_eq!(p.name(), "version");
+    }
+
+    #[test]
+    fn test_version_plugin_handler_name() {
+        let handlers = VersionPlugin::new().handlers();
+        assert_eq!(handlers.len(), 1);
+        assert_eq!(handlers[0].0, "system_version");
+    }
+
+    #[test]
+    fn test_version_plugin_with_config() {
+        let plugin = VersionPlugin::new().with_config(test_config());
+        assert!(plugin.config.is_some());
+        assert_eq!(plugin.config.unwrap().metadata.version, "2.0.0");
+    }
+
+    #[test]
+    fn test_version_handler_executes_with_config() {
+        let plugin = VersionPlugin::new().with_config(test_config());
+        let handlers = plugin.handlers();
+        let (_, handler) = &handlers[0];
+        let mut ctx = TestContext;
+        assert!(handler
+            .execute(&mut ctx, &ParsedArgs::from_scalars(HashMap::new()))
+            .is_ok());
+    }
+
+    #[test]
+    fn test_version_handler_executes_without_config() {
+        let handlers = VersionPlugin::new().handlers();
+        let (_, handler) = &handlers[0];
+        let mut ctx = TestContext;
+        assert!(handler
+            .execute(&mut ctx, &ParsedArgs::from_scalars(HashMap::new()))
+            .is_ok());
+    }
+
+    #[test]
+    fn test_version_plugin_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>(_: T) {}
+        assert_send_sync(VersionPlugin::new());
+    }
+}

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -1,25 +1,25 @@
 //! Plugin system for `dynamic-cli`
 //!
 //! This module defines the [`Plugin`] trait, the standard extension mechanism
-//! for `dynamic-cli` applications. A builtin groups related command handlers
+//! for `dynamic-cli` applications. A plugin groups related command handlers
 //! under a single unit of deployment with explicit metadata.
 //!
 //! # Design
 //!
-//! The builtin system follows the principle established by DD-001 and DD-002:
+//! The plugin system follows the principle established by DD-001 and DD-002:
 //! - **The YAML config is the sole source of truth** for command definitions.
 //! - **Plugins supply handlers only** — identified by their `implementation`
 //!   name, exactly as [`CliBuilder::register_handler`] does.
-//! - **The framework controls registration** — the builtin declares what it
+//! - **The framework controls registration** — the plugin declares what it
 //!   provides via [`Plugin::handlers`]; the framework validates and registers.
-//!   The builtin never receives a `&mut CommandRegistry`.
+//!   The plugin never receives a `&mut CommandRegistry`.
 //!
-//! # Standard builtin
+//! # Standard plugin
 //!
 //! [`SystemPlugin`] is provided out of the box. It supplies handlers for the
 //! common system commands (`help`, `version`, `exit` / `quit`) that every
 //! application typically needs. Users declare the corresponding commands in
-//! their YAML config and register the builtin with a single call.
+//! their YAML config and register the plugin with a single call.
 //!
 //! # Example
 //!
@@ -27,7 +27,7 @@
 //! use dynamic_cli::plugin::{Plugin, SystemPlugin};
 //! use dynamic_cli::executor::{CommandHandler, ParsedArgs};
 //!
-//! // A minimal builtin supplying one handler
+//! // A minimal plugin supplying one handler
 //! struct GreetPlugin;
 //!
 //! impl Plugin for GreetPlugin {
@@ -52,9 +52,9 @@
 //! }
 //!
 //! // Verify the trait contract
-//! let builtin = GreetPlugin;
-//! assert_eq!(builtin.name(), "greet");
-//! let handlers = builtin.handlers();
+//! let plugin = GreetPlugin;
+//! assert_eq!(plugin.name(), "greet");
+//! let handlers = plugin.handlers();
 //! assert_eq!(handlers.len(), 1);
 //! assert_eq!(handlers[0].0, "greet_hello");
 //! ```
@@ -74,6 +74,12 @@ pub mod builtin;
 pub mod wasm;
 
 // Re-exports for convenience
+#[cfg(feature = "config-plugin")]
+pub use builtin::ConfigPlugin;
+#[cfg(feature = "env-plugin")]
+pub use builtin::EnvPlugin;
+#[cfg(feature = "sysinfo-plugin")]
+pub use builtin::SysInfoPlugin;
 pub use builtin::{ExitPlugin, HelpPlugin, VersionPlugin};
 pub use system::SystemPlugin;
 
@@ -83,9 +89,9 @@ pub use system::SystemPlugin;
 
 /// Extension point for grouping related command handlers.
 ///
-/// A builtin declares its metadata and the handlers it provides. The framework
+/// A plugin declares its metadata and the handlers it provides. The framework
 /// validates and registers those handlers into the [`CommandRegistry`] during
-/// [`CliBuilder::build()`]. The builtin never has direct access to the registry.
+/// [`CliBuilder::build()`]. The plugin never has direct access to the registry.
 ///
 /// # Contract
 ///
@@ -94,7 +100,7 @@ pub use system::SystemPlugin;
 ///   command declared in the YAML config — exactly as with
 ///   [`CliBuilder::register_handler`].
 /// - The YAML config remains the sole source of truth for command definitions.
-///   A builtin cannot inject commands that are not declared in the config.
+///   A plugin cannot inject commands that are not declared in the config.
 ///
 /// # Object safety
 ///
@@ -115,9 +121,9 @@ pub use system::SystemPlugin;
 /// struct MyPlugin;
 ///
 /// impl Plugin for MyPlugin {
-///     fn name(&self) -> &str { "my-builtin" }
+///     fn name(&self) -> &str { "my-plugin" }
 ///     fn version(&self) -> &str { "1.0.0" }
-///     fn description(&self) -> &str { "My custom builtin" }
+///     fn description(&self) -> &str { "My custom plugin" }
 ///
 ///     fn handlers(&self) -> Vec<(String, Box<dyn CommandHandler>)> {
 ///         struct MyHandler;
@@ -136,22 +142,22 @@ pub use system::SystemPlugin;
 /// }
 ///
 /// // Trait object usage (object-safe)
-/// let builtin: Box<dyn Plugin> = Box::new(MyPlugin);
-/// assert_eq!(builtin.name(), "my-builtin");
-/// assert_eq!(builtin.version(), "1.0.0");
-/// assert_eq!(builtin.handlers().len(), 1);
+/// let plugin: Box<dyn Plugin> = Box::new(MyPlugin);
+/// assert_eq!(plugin.name(), "my-plugin");
+/// assert_eq!(plugin.version(), "1.0.0");
+/// assert_eq!(plugin.handlers().len(), 1);
 /// ```
 pub trait Plugin: Send + Sync {
-    /// Short identifier for this builtin (e.g. `"system"`, `"greet"`).
+    /// Short identifier for this plugin (e.g. `"system"`, `"greet"`).
     fn name(&self) -> &str;
 
     /// Semantic version string (e.g. `"1.0.0"`).
     fn version(&self) -> &str;
 
-    /// Human-readable description of what this builtin provides.
+    /// Human-readable description of what this plugin provides.
     fn description(&self) -> &str;
 
-    /// Returns the handlers this builtin contributes.
+    /// Returns the handlers this plugin contributes.
     ///
     /// Each element is `(implementation_name, handler)` where
     /// `implementation_name` matches the `implementation` field in the YAML
@@ -283,7 +289,7 @@ mod tests {
     }
 
     // -------------------------------------------------------------------------
-    // EchoPlugin — minimal single-handler builtin
+    // EchoPlugin — minimal single-handler plugin
     // -------------------------------------------------------------------------
 
     #[test]

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -1,25 +1,25 @@
 //! Plugin system for `dynamic-cli`
 //!
 //! This module defines the [`Plugin`] trait, the standard extension mechanism
-//! for `dynamic-cli` applications. A plugin groups related command handlers
+//! for `dynamic-cli` applications. A builtin groups related command handlers
 //! under a single unit of deployment with explicit metadata.
 //!
 //! # Design
 //!
-//! The plugin system follows the principle established by DD-001 and DD-002:
+//! The builtin system follows the principle established by DD-001 and DD-002:
 //! - **The YAML config is the sole source of truth** for command definitions.
 //! - **Plugins supply handlers only** — identified by their `implementation`
 //!   name, exactly as [`CliBuilder::register_handler`] does.
-//! - **The framework controls registration** — the plugin declares what it
+//! - **The framework controls registration** — the builtin declares what it
 //!   provides via [`Plugin::handlers`]; the framework validates and registers.
-//!   The plugin never receives a `&mut CommandRegistry`.
+//!   The builtin never receives a `&mut CommandRegistry`.
 //!
-//! # Standard plugin
+//! # Standard builtin
 //!
 //! [`SystemPlugin`] is provided out of the box. It supplies handlers for the
 //! common system commands (`help`, `version`, `exit` / `quit`) that every
 //! application typically needs. Users declare the corresponding commands in
-//! their YAML config and register the plugin with a single call.
+//! their YAML config and register the builtin with a single call.
 //!
 //! # Example
 //!
@@ -27,7 +27,7 @@
 //! use dynamic_cli::plugin::{Plugin, SystemPlugin};
 //! use dynamic_cli::executor::{CommandHandler, ParsedArgs};
 //!
-//! // A minimal plugin supplying one handler
+//! // A minimal builtin supplying one handler
 //! struct GreetPlugin;
 //!
 //! impl Plugin for GreetPlugin {
@@ -52,9 +52,9 @@
 //! }
 //!
 //! // Verify the trait contract
-//! let plugin = GreetPlugin;
-//! assert_eq!(plugin.name(), "greet");
-//! let handlers = plugin.handlers();
+//! let builtin = GreetPlugin;
+//! assert_eq!(builtin.name(), "greet");
+//! let handlers = builtin.handlers();
 //! assert_eq!(handlers.len(), 1);
 //! assert_eq!(handlers[0].0, "greet_hello");
 //! ```
@@ -64,11 +64,17 @@ use crate::executor::CommandHandler;
 // Sub-modules
 pub mod system;
 
+// Standalone, single-command plugins split out of `SystemPlugin` (#44 / DD-025).
+// Each of `HelpPlugin`, `VersionPlugin`, `ExitPlugin` contributes exactly one
+// handler, reusing `system`'s handler logic internally — no duplication.
+pub mod builtin;
+
 // Sub-module for the WASM loader (feature-gated, added in #23)
 #[cfg(feature = "wasm-plugins")]
 pub mod wasm;
 
 // Re-exports for convenience
+pub use builtin::{ExitPlugin, HelpPlugin, VersionPlugin};
 pub use system::SystemPlugin;
 
 // ============================================================================
@@ -77,9 +83,9 @@ pub use system::SystemPlugin;
 
 /// Extension point for grouping related command handlers.
 ///
-/// A plugin declares its metadata and the handlers it provides. The framework
+/// A builtin declares its metadata and the handlers it provides. The framework
 /// validates and registers those handlers into the [`CommandRegistry`] during
-/// [`CliBuilder::build()`]. The plugin never has direct access to the registry.
+/// [`CliBuilder::build()`]. The builtin never has direct access to the registry.
 ///
 /// # Contract
 ///
@@ -88,7 +94,7 @@ pub use system::SystemPlugin;
 ///   command declared in the YAML config — exactly as with
 ///   [`CliBuilder::register_handler`].
 /// - The YAML config remains the sole source of truth for command definitions.
-///   A plugin cannot inject commands that are not declared in the config.
+///   A builtin cannot inject commands that are not declared in the config.
 ///
 /// # Object safety
 ///
@@ -109,9 +115,9 @@ pub use system::SystemPlugin;
 /// struct MyPlugin;
 ///
 /// impl Plugin for MyPlugin {
-///     fn name(&self) -> &str { "my-plugin" }
+///     fn name(&self) -> &str { "my-builtin" }
 ///     fn version(&self) -> &str { "1.0.0" }
-///     fn description(&self) -> &str { "My custom plugin" }
+///     fn description(&self) -> &str { "My custom builtin" }
 ///
 ///     fn handlers(&self) -> Vec<(String, Box<dyn CommandHandler>)> {
 ///         struct MyHandler;
@@ -130,22 +136,22 @@ pub use system::SystemPlugin;
 /// }
 ///
 /// // Trait object usage (object-safe)
-/// let plugin: Box<dyn Plugin> = Box::new(MyPlugin);
-/// assert_eq!(plugin.name(), "my-plugin");
-/// assert_eq!(plugin.version(), "1.0.0");
-/// assert_eq!(plugin.handlers().len(), 1);
+/// let builtin: Box<dyn Plugin> = Box::new(MyPlugin);
+/// assert_eq!(builtin.name(), "my-builtin");
+/// assert_eq!(builtin.version(), "1.0.0");
+/// assert_eq!(builtin.handlers().len(), 1);
 /// ```
 pub trait Plugin: Send + Sync {
-    /// Short identifier for this plugin (e.g. `"system"`, `"greet"`).
+    /// Short identifier for this builtin (e.g. `"system"`, `"greet"`).
     fn name(&self) -> &str;
 
     /// Semantic version string (e.g. `"1.0.0"`).
     fn version(&self) -> &str;
 
-    /// Human-readable description of what this plugin provides.
+    /// Human-readable description of what this builtin provides.
     fn description(&self) -> &str;
 
-    /// Returns the handlers this plugin contributes.
+    /// Returns the handlers this builtin contributes.
     ///
     /// Each element is `(implementation_name, handler)` where
     /// `implementation_name` matches the `implementation` field in the YAML
@@ -277,7 +283,7 @@ mod tests {
     }
 
     // -------------------------------------------------------------------------
-    // EchoPlugin — minimal single-handler plugin
+    // EchoPlugin — minimal single-handler builtin
     // -------------------------------------------------------------------------
 
     #[test]

--- a/src/plugin/system.rs
+++ b/src/plugin/system.rs
@@ -1,6 +1,6 @@
-//! Built-in system plugin for `dynamic-cli`
+//! Built-in system builtin for `dynamic-cli`
 //!
-//! Provides [`SystemPlugin`], a ready-made plugin supplying the three handlers
+//! Provides [`SystemPlugin`], a ready-made builtin supplying the three handlers
 //! that every `dynamic-cli` application typically needs: `system_help`,
 //! `system_version`, and `system_exit`.
 //!
@@ -19,11 +19,11 @@ use std::sync::Arc;
 // SystemPlugin
 // ============================================================================
 
-/// Built-in plugin providing standard system commands.
+/// Built-in builtin providing standard system commands.
 ///
 /// Supplies ready-made handlers for the commands that every `dynamic-cli`
 /// application typically needs. Users declare the corresponding commands in
-/// their YAML config and register the plugin once — no manual handler wiring.
+/// their YAML config and register the builtin once — no manual handler wiring.
 ///
 /// # Provided handlers
 ///
@@ -45,7 +45,7 @@ use std::sync::Arc;
 /// ```no_run
 /// use dynamic_cli::plugin::SystemPlugin;
 ///
-/// let plugin = SystemPlugin::new()
+/// let builtin = SystemPlugin::new()
 ///     .with_exit_fn(|| {
 ///         // flush logs, close DB connections, save session…
 ///         eprintln!("Goodbye.");
@@ -88,10 +88,10 @@ use std::sync::Arc;
 /// ```
 /// use dynamic_cli::plugin::{Plugin, SystemPlugin};
 ///
-/// let plugin = SystemPlugin::new();
-/// assert_eq!(plugin.name(), "system");
+/// let builtin = SystemPlugin::new();
+/// assert_eq!(builtin.name(), "system");
 ///
-/// let handlers = plugin.handlers();
+/// let handlers = builtin.handlers();
 /// let names: Vec<&str> = handlers.iter().map(|(n, _)| n.as_str()).collect();
 /// assert!(names.contains(&"system_help"));
 /// assert!(names.contains(&"system_version"));
@@ -133,7 +133,7 @@ impl SystemPlugin {
 
     /// Attach a config so the system handlers can access app metadata.
     ///
-    /// Called automatically by [`CliBuilder::build()`] when the plugin is
+    /// Called automatically by [`CliBuilder::build()`] when the builtin is
     /// registered via [`CliBuilder::register_plugin`].
     ///
     /// # Example
@@ -152,8 +152,8 @@ impl SystemPlugin {
     ///     global_options: vec![],
     /// };
     ///
-    /// let plugin = SystemPlugin::new().with_config(config);
-    /// assert_eq!(plugin.name(), "system");
+    /// let builtin = SystemPlugin::new().with_config(config);
+    /// assert_eq!(builtin.name(), "system");
     /// ```
     pub fn with_config(mut self, config: CommandsConfig) -> Self {
         self.config = Some(config);
@@ -215,17 +215,15 @@ impl Plugin for SystemPlugin {
         vec![
             (
                 "system_help".to_string(),
-                Box::new(SystemHelpHandler {
-                    config: config.clone(),
-                }),
+                Box::new(SystemHelpHandler::new(config.clone())),
             ),
             (
                 "system_version".to_string(),
-                Box::new(SystemVersionHandler { config }),
+                Box::new(SystemVersionHandler::new(config)),
             ),
             (
                 "system_exit".to_string(),
-                Box::new(SystemExitHandler { exit_fn }),
+                Box::new(SystemExitHandler::new(exit_fn)),
             ),
         ]
     }
@@ -236,8 +234,18 @@ impl Plugin for SystemPlugin {
 // ============================================================================
 
 /// Handler for `system_help` — prints app-level or per-command help.
-struct SystemHelpHandler {
+///
+/// `pub(crate)` so [`crate::plugin::builtin::HelpPlugin`] can reuse the
+/// exact same logic without duplicating it (see #44 / DD-025).
+pub(crate) struct SystemHelpHandler {
     config: Option<CommandsConfig>,
+}
+
+impl SystemHelpHandler {
+    /// Build a new handler carrying the given (optional) config.
+    pub(crate) fn new(config: Option<CommandsConfig>) -> Self {
+        Self { config }
+    }
 }
 
 impl CommandHandler for SystemHelpHandler {
@@ -261,8 +269,18 @@ impl CommandHandler for SystemHelpHandler {
 }
 
 /// Handler for `system_version` — prints the app version from config metadata.
-struct SystemVersionHandler {
+///
+/// `pub(crate)` so [`crate::plugin::builtin::VersionPlugin`] can
+/// reuse the exact same logic without duplicating it (see #44 / DD-025).
+pub(crate) struct SystemVersionHandler {
     config: Option<CommandsConfig>,
+}
+
+impl SystemVersionHandler {
+    /// Build a new handler carrying the given (optional) config.
+    pub(crate) fn new(config: Option<CommandsConfig>) -> Self {
+        Self { config }
+    }
 }
 
 impl CommandHandler for SystemVersionHandler {
@@ -279,9 +297,19 @@ impl CommandHandler for SystemVersionHandler {
 ///
 /// The callback is set via [`SystemPlugin::with_exit_fn`]. The default
 /// callback calls `std::process::exit(0)`.
-struct SystemExitHandler {
+///
+/// `pub(crate)` so [`crate::plugin::builtin::ExitPlugin`] can reuse the
+/// exact same logic without duplicating it (see #44 / DD-025).
+pub(crate) struct SystemExitHandler {
     /// Shutdown callback — runs before the process exits.
     exit_fn: Arc<dyn Fn() + Send + Sync>,
+}
+
+impl SystemExitHandler {
+    /// Build a new handler carrying the given shutdown callback.
+    pub(crate) fn new(exit_fn: Arc<dyn Fn() + Send + Sync>) -> Self {
+        Self { exit_fn }
+    }
 }
 
 impl CommandHandler for SystemExitHandler {
@@ -443,7 +471,7 @@ mod tests {
     fn test_system_exit_default_callback_is_set() {
         // Verify that SystemPlugin::new() initialises exit_fn without panicking.
         // The default callback (process::exit) cannot be invoked in tests;
-        // we only check that the plugin builds and exposes the handler.
+        // we only check that the builtin builds and exposes the handler.
         let plugin = SystemPlugin::new();
         let handlers = plugin.handlers();
         assert!(handlers.iter().any(|(n, _)| n == "system_exit"));

--- a/src/registry/command_registry.rs
+++ b/src/registry/command_registry.rs
@@ -705,20 +705,8 @@ impl Default for CommandRegistry {
 mod tests {
     use super::*;
     use crate::parser::ParsedArgs;
-    use std::any::Any;
 
     // Test fixtures
-    #[derive(Default)]
-    struct TestContext;
-
-    impl crate::context::ExecutionContext for TestContext {
-        fn as_any(&self) -> &dyn Any {
-            self
-        }
-        fn as_any_mut(&mut self) -> &mut dyn Any {
-            self
-        }
-    }
 
     struct TestHandler;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -606,6 +606,10 @@ mod tests {
     }
 
     #[test]
+    // `3.14` is an intentional, intuitive decimal literal for testing string
+    // parsing — not a mistyped π. clippy::approx_constant would otherwise
+    // suggest std::f64::consts::PI, which is not what this test is about.
+    #[allow(clippy::approx_constant)]
     fn test_parse_float_valid() {
         assert_eq!(parse_float("3.14", "pi").unwrap(), 3.14);
         assert_eq!(parse_float("42", "value").unwrap(), 42.0);
@@ -614,15 +618,15 @@ mod tests {
 
     #[test]
     fn test_parse_bool_various() {
-        assert_eq!(parse_bool("true").unwrap(), true);
-        assert_eq!(parse_bool("YES").unwrap(), true);
-        assert_eq!(parse_bool("1").unwrap(), true);
-        assert_eq!(parse_bool("on").unwrap(), true);
+        assert!(parse_bool("true").unwrap());
+        assert!(parse_bool("YES").unwrap());
+        assert!(parse_bool("1").unwrap());
+        assert!(parse_bool("on").unwrap());
 
-        assert_eq!(parse_bool("false").unwrap(), false);
-        assert_eq!(parse_bool("no").unwrap(), false);
-        assert_eq!(parse_bool("0").unwrap(), false);
-        assert_eq!(parse_bool("off").unwrap(), false);
+        assert!(!parse_bool("false").unwrap());
+        assert!(!parse_bool("no").unwrap());
+        assert!(!parse_bool("0").unwrap());
+        assert!(!parse_bool("off").unwrap());
 
         assert!(parse_bool("maybe").is_err());
     }

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -280,7 +280,7 @@ mod tests {
     #[test]
     fn test_validate_fails_at_first_invalid_rule() {
         let f = temp_file_with_ext("txt", "content");
-        let rules = vec![
+        let rules = [
             ValidationRule::MustExist { must_exist: true },
             ValidationRule::Extensions {
                 extensions: vec!["csv".to_string()], // Wrong extension!

--- a/tests/integration/async_token_test.rs
+++ b/tests/integration/async_token_test.rs
@@ -28,15 +28,13 @@ use std::time::{Duration, Instant};
 // Test fixtures
 // ============================================================================
 
-/// Execution context that records the token(s) received.
+/// Execution context placeholder for these tests.
 ///
-/// Shared via `Arc<Mutex<_>>` so the test can inspect side effects after
-/// `run_cli()` returns (handlers only receive `&mut dyn ExecutionContext`,
-/// not an owned, inspectable value).
-#[derive(Default)]
-struct TokenContext {
-    tokens: Arc<Mutex<Vec<String>>>,
-}
+/// The actual recording mechanism lives in [`TokenFetchHandler`]'s own
+/// `tokens` field, shared with the test via a separate `Arc<Mutex<_>>`
+/// clone — this context doesn't need to hold anything itself, only to
+/// satisfy `ExecutionContext`.
+struct TokenContext;
 
 impl ExecutionContext for TokenContext {
     fn as_any(&self) -> &dyn Any {
@@ -110,7 +108,7 @@ fn async_token_handler_executes_via_full_chain() {
 
     let app = CliBuilder::new()
         .config(test_config())
-        .context(Box::new(TokenContext::default()))
+        .context(Box::new(TokenContext))
         .register_async_handler(
             "token_handler",
             Box::new(TokenFetchHandler {
@@ -149,7 +147,7 @@ fn async_token_handler_alias_resolves() {
 
     let app = CliBuilder::new()
         .config(test_config())
-        .context(Box::new(TokenContext::default()))
+        .context(Box::new(TokenContext))
         .register_async_handler(
             "token_handler",
             Box::new(TokenFetchHandler {
@@ -174,7 +172,7 @@ fn async_token_handler_alias_resolves() {
 fn required_command_satisfied_by_async_handler_only() {
     let app = CliBuilder::new()
         .config(test_config()) // "fetch-token" is `required: true`
-        .context(Box::new(TokenContext::default()))
+        .context(Box::new(TokenContext))
         .register_async_handler(
             "token_handler",
             Box::new(TokenFetchHandler {

--- a/tests/integration/system_plugin_test.rs
+++ b/tests/integration/system_plugin_test.rs
@@ -21,15 +21,13 @@ use std::sync::{Arc, Mutex};
 // Test fixtures
 // ============================================================================
 
-/// Execution context that records invocations of the user-defined handler.
+/// Execution context placeholder for these tests.
 ///
-/// Shared via `Arc<Mutex<_>>` so the test can inspect side effects after
-/// `run_cli()` returns (handlers only receive `&mut dyn ExecutionContext`,
-/// not an owned, inspectable value).
-#[derive(Default)]
-struct RecordingContext {
-    greeted: Arc<Mutex<Vec<String>>>,
-}
+/// The actual recording mechanism lives in [`GreetHandler`]'s own
+/// `greeted` field, shared with the test via a separate `Arc<Mutex<_>>`
+/// clone — this context doesn't need to hold anything itself, only to
+/// satisfy `ExecutionContext`.
+struct RecordingContext;
 
 impl ExecutionContext for RecordingContext {
     fn as_any(&self) -> &dyn Any {
@@ -120,7 +118,7 @@ fn test_config() -> CommandsConfig {
 fn system_plugin_version_command_executes_via_full_chain() {
     let app = CliBuilder::new()
         .config(test_config())
-        .context(Box::new(RecordingContext::default()))
+        .context(Box::new(RecordingContext))
         .register_plugin(Box::new(SystemPlugin::new()))
         .register_sync_handler(
             "greet_handler",
@@ -144,7 +142,7 @@ fn system_plugin_version_command_executes_via_full_chain() {
 fn system_plugin_help_command_executes_via_full_chain() {
     let app = CliBuilder::new()
         .config(test_config())
-        .context(Box::new(RecordingContext::default()))
+        .context(Box::new(RecordingContext))
         .register_plugin(Box::new(SystemPlugin::new()))
         .register_sync_handler(
             "greet_handler",
@@ -170,7 +168,7 @@ fn system_plugin_coexists_with_user_registered_handler() {
 
     let app = CliBuilder::new()
         .config(test_config())
-        .context(Box::new(RecordingContext::default()))
+        .context(Box::new(RecordingContext))
         .register_plugin(Box::new(SystemPlugin::new()))
         .register_sync_handler(
             "greet_handler",
@@ -200,7 +198,7 @@ fn system_plugin_coexists_with_user_registered_handler() {
 fn system_plugin_alias_resolves_to_same_handler() {
     let app = CliBuilder::new()
         .config(test_config())
-        .context(Box::new(RecordingContext::default()))
+        .context(Box::new(RecordingContext))
         .register_plugin(Box::new(SystemPlugin::new()))
         .register_sync_handler(
             "greet_handler",
@@ -223,7 +221,7 @@ fn system_plugin_alias_resolves_to_same_handler() {
 fn duplicate_plugin_registration_fails_at_build() {
     let result = CliBuilder::new()
         .config(test_config())
-        .context(Box::new(RecordingContext::default()))
+        .context(Box::new(RecordingContext))
         .register_plugin(Box::new(SystemPlugin::new()))
         .register_plugin(Box::new(SystemPlugin::new()))
         .register_sync_handler(


### PR DESCRIPTION
## Summary
 
Implements the full v0.7.0 · Static Plugin Library milestone: four granular plugins split out of `SystemPlugin`, batch command execution (`run_script` / `:load`), a new example, and a CI/clippy maintenance pass surfaced while validating the above.
 
Closes #41, #44, #45, #46, #47, #49.
 
## What's included
 
### Granular plugins (#44, #45, #46, #47 — #25)
 
- `HelpPlugin`, `VersionPlugin`, `ExitPlugin` — `SystemPlugin`'s three bundled commands, now independently composable. Zero duplicated logic (`SystemPlugin`'s own handlers made `pub(crate)` and reused internally); `SystemPlugin`'s public API and test suite unchanged.
- `SysInfoPlugin` (feature `sysinfo-plugin`) — OS/arch/parallelism, `std`-only, no new dependency.
- `EnvPlugin` (feature `env-plugin`) — filtered environment variable display; filtering rule (deny-list: `SECRET`, `TOKEN`, `KEY`, `PASS`, `CREDENTIAL`, `AUTH`, `PRIVATE`) decided during implementation, as the issue left it open.
- `ConfigPlugin` (feature `config-plugin`) — `config_show` / `config_validate`, the latter calling `crate::config::validate_config`
  directly (same function `build()` already runs, no duplicated logic).

All four re-exported from crate root and `prelude`, cfg-gated where flagged. **Naming correction**: issue bodies say `src/plugin/static/` — implemented as `src/plugin/builtin/` instead (`static` is a reserved Rust keyword; see #44's closing comment for the full rationale).
 
### Batch execution (#41)
 
- `CliInterface::run_script()` / `CliApp::run_script()` — dispatch a file of command lines through the existing resolve → parse → execute path, `ScriptErrorPolicy::{Abort, Continue}`, `ScriptOutcome` with per-line failure reporting.
- `:load <path>` REPL meta-command — load a script from an already-running REPL session (deliberately on REPL's existing
  scalar-only parse path, not `run_script()`'s typed path). 

**Architectural note**: "ScriptLoaderPlugin", as scoped in the issue, turned out to be impossible as a `Plugin` — `CommandHandler::execute` never receives the `CommandRegistry`, so a plugin-contributed handler cannot dispatch other commands. Reframed as methods on `CliInterface`/`CliApp` instead. Additive, no breaking change.
 
### New example
 
- `examples/advanced_rpn_calculator.rs` — HP-41CX-flavored extension of `rpn_calculator.rs`: scientific functions, a 10-slot memory bank (`sto`/`rcl`), `SysInfoPlugin` + `ConfigPlugin` registered together, `--script` and `:load` both exercised.

### Bug fix
 
- `rpn_calculator.rs` / `advanced_rpn_calculator.rs`: `sub`/`div` computed `X - Y` / `X / Y` instead of the HP RPN convention
  `Y - X` / `Y / X` (`"10 ENTER 3 -"` returned `-7`, not `7`). Untested before now — only the commutative `mul` had a test.
  Regression tests added to both.

### Maintenance (#49)
 
- 43 pre-existing clippy errors, unrelated to this release, traced to an unpinned CI toolchain (`ci.yml` never installed an explicit Rust version, drifting with `ubuntu-latest`). Fixed at the root: all four `ci.yml` jobs now pin `dtolnay/rust-toolchain@1.97.0`; `clippy` job gained a combined `--all-features` step.

## Testing
 
```
cargo clean
cargo check
cargo build --all-features
cargo fmt --check
cargo clippy --all-features -- -D warnings
cargo test --all-features
```
 
All green. `cargo test --all-features` does not build examples or integration-test the feature-gated plugin unit tests without
`--all-targets` — noted as a follow-up gap in `ci.yml`'s `test` job (not addressed in this PR; `clippy`'s equivalent gap was).
 
## Not included (deferred)
 
- Code coverage measurement (`cargo-llvm-cov`) — not run this sprint.
- `README.md` / `README.fr.md` updates — planned for the staging → master PR, alongside the version bump and release tag.
- `ci.yml`'s `test` job still lacks a combined `--all-features` (and `--all-targets`, for examples) step, unlike `clippy`'s.
- `coverage.yml` still pins `@stable` (floating), not a fixed version.

## Related
 
- #25 DD-025
- #48 DD-027 (spun out of the DD-025 triage, not yet scheduled)
